### PR TITLE
[codex] add Workers AI CAG and refresh workflow

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -4,3 +4,4 @@
 LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token-here
 LINE_CHANNEL_SECRET=your-line-channel-secret-here
 ASK_MODEL=@cf/moonshotai/kimi-k2.6
+ASK_ARCHIVE_BASE_URL=https://archive.tw

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -3,3 +3,4 @@
 # Copy this file to .dev.vars and fill in the real values (.dev.vars is gitignored)
 LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token-here
 LINE_CHANNEL_SECRET=your-line-channel-secret-here
+ASK_MODEL=@cf/moonshotai/kimi-k2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - codex/worker-ai-cag
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Validate Worker bundle
+        run: npx wrangler deploy --dry-run --outdir /tmp/askit-hono-dry-run

--- a/.github/workflows/refresh-cag-index.yml
+++ b/.github/workflows/refresh-cag-index.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: Deploy the Worker after refreshing the R2 index
+        description: Deploy the Worker after refreshing the R2 index as an optional cache reset
         required: true
         type: boolean
         default: false
@@ -54,5 +54,5 @@ jobs:
         run: npx wrangler deploy --dry-run --outdir /tmp/askit-hono-dry-run
 
       - name: Deploy Worker to refresh runtime cache
-        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.deploy) }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
         run: npm run deploy

--- a/.github/workflows/refresh-cag-index.yml
+++ b/.github/workflows/refresh-cag-index.yml
@@ -1,10 +1,10 @@
-name: Refresh CAG index
+name: Refresh Ask index
 
 on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: Deploy the Worker after refreshing the R2 index as an optional cache reset
+        description: Deploy the Worker after refreshing the R2 ask index as an optional cache reset
         required: true
         type: boolean
         default: false
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: refresh-cag-index-${{ github.ref }}
+  group: refresh-ask-index-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -47,8 +47,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Refresh long-lore index in R2
-        run: npm run build:index:lore
+      - name: Refresh R2 index
+        run: npm run build:index
 
       - name: Validate Worker bundle
         run: npx wrangler deploy --dry-run --outdir /tmp/askit-hono-dry-run

--- a/.github/workflows/refresh-cag-index.yml
+++ b/.github/workflows/refresh-cag-index.yml
@@ -1,0 +1,58 @@
+name: Refresh CAG index
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: Deploy the Worker after refreshing the R2 index
+        required: true
+        type: boolean
+        default: false
+  repository_dispatch:
+    types:
+      - sayit-updated
+  schedule:
+    # Backstop in case the upstream transcript dispatch is missed.
+    - cron: "30 13 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-cag-index-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      R2_BUCKET: askit-fuse-index-cache
+      R2_KEY: ask-index/audrey-tang.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Refresh long-lore index in R2
+        run: npm run build:index:lore
+
+      - name: Validate Worker bundle
+        run: npx wrangler deploy --dry-run --outdir /tmp/askit-hono-dry-run
+
+      - name: Deploy Worker to refresh runtime cache
+        if: ${{ github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.deploy) }}
+        run: npm run deploy

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 *.log
 dist/
 .DS_Store
+build/*.manifest.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 | --- | --- |
 | `GET /` | Healthcheck，回 `Hello World!` |
 | `GET /ask/:question` | **暫時測試用**：把 question URL-decode 後跑搜尋，回傳 HTML 顯示最相近段落 + 原文連結。方便用瀏覽器或 curl 驗證索引與搜尋結果。 |
+| `GET /cag/:question` | 以同一份 R2 索引取回多段 SayIt 來源，組成 CAG prompt，呼叫 Cloudflare Workers AI（預設 Kimi K2.6），並串流 Markdown 回答與 `archive.tw#s...` footnote。 |
+| `POST /cag` | JSON 版本的 CAG endpoint：`{ "question": "...", "topK": 6 }`，同樣串流 Markdown。 |
 | `POST /webhook` | LINE Messaging API webhook。收到 LINE 文字訊息後，使用與 `/ask/:question` 相同的搜尋 pipeline，並以 Flex Message 回覆最相近段落、出處、日期與原文連結。 |
 
 ### 回覆格式
@@ -93,6 +95,19 @@ npm run build:index
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 物件 key |
 | `LOCAL=1` | — | 對 D1 下 `--local`（預設 `--remote` 用線上資料庫） |
 | `SKIP_UPLOAD=1` | — | 只在 `build/` 產出 JSON 不上傳 |
+
+#### CAG + Workers AI
+
+`/cag/:question` 是把 DS4 CAG 實驗搬進 Cloudflare runtime 的部分：
+retrieve 仍然使用 build-time R2 Fuse index，runtime 不查 D1；生成改由 Workers AI
+binding `AI` 執行，預設模型由 `ASK_MODEL` 控制。
+
+```bash
+curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
+```
+
+輸出是 streaming Markdown。模型若輸出 `[1]` 這類來源標記，Worker 會轉成
+`[^1]` 並在結尾補上 footnote，連到對應的 `archive.tw/<speech>#s<section_id>`。
 
 #### 本機開發
 
@@ -252,6 +267,8 @@ Built with [Hono](https://hono.dev/) on Cloudflare Workers. The Worker does **no
 | --- | --- |
 | `GET /` | Healthcheck — returns `Hello World!` |
 | `GET /ask/:question` | **Temporary debug endpoint** — URL-decodes the question, runs the search, returns HTML with the closest section and a link to the source. Handy for testing from a browser or `curl`. |
+| `GET /cag/:question` | Retrieves multiple SayIt sections from the same R2 index, builds a CAG prompt, calls Cloudflare Workers AI (Kimi K2.6 by default), and streams Markdown with `archive.tw#s...` footnotes. |
+| `POST /cag` | JSON CAG endpoint: `{ "question": "...", "topK": 6 }`, also streaming Markdown. |
 | `POST /webhook` | LINE Messaging API webhook. For text messages, it uses the same search pipeline as `/ask/:question` and replies with the closest section, source, date, and source link as a Flex Message. |
 
 ### Reply Format
@@ -329,6 +346,21 @@ Optional environment variables:
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 object key |
 | `LOCAL=1` | — | Use `--local` against D1 (defaults to `--remote`) |
 | `SKIP_UPLOAD=1` | — | Write the JSON to `build/` only, skip the R2 upload |
+
+#### CAG + Workers AI
+
+`/cag/:question` is the Cloudflare-native slice of the DS4 CAG experiment:
+retrieval still uses the build-time R2 Fuse index, so runtime does not query D1;
+generation runs through the Workers AI `AI` binding. The default model is
+controlled by `ASK_MODEL`.
+
+```bash
+curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
+```
+
+The response is streaming Markdown. If the model emits source markers like
+`[1]`, the Worker rewrites them to `[^1]` and appends footnotes linked to the
+matching `archive.tw/<speech>#s<section_id>` source.
 
 #### Run locally
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 讓使用者向 LINE Bot 提問（例如「AI 會不會控制我們」），Bot 從 [SayIt](https://archive.tw)（亦即 sayit-hono 專案）的逐字稿中找出指定講者（預設「唐鳳」）說過、最相近的一段話回覆，並附上原文連結。
 
-實作上以 [Hono](https://hono.dev/) 跑在 Cloudflare Workers，不在 runtime 查 D1，而是靠 build-time script 從 D1 預先撈段落、用 [Fuse.js](https://www.fusejs.io/) 建好索引、上傳到 R2；Worker 啟動時從 R2 讀回索引做 fuzzy 搜尋。
+實作上以 [Hono](https://hono.dev/) 跑在 Cloudflare Workers。LINE `/webhook` 與 `/ask/:question` 走 build-time R2 Fuse 索引；`/cag` 則直接使用 `archive.tw` 的搜尋 API 與 section API 做 long-lore retrieval，避免 Worker 冷啟動時載入巨大索引。
 
 ### 功能與路由
 
@@ -16,7 +16,8 @@
 | --- | --- |
 | `GET /` | Healthcheck，回 `Hello World!` |
 | `GET /ask/:question` | **暫時測試用**：把 question URL-decode 後跑搜尋，回傳 HTML 顯示最相近段落 + 原文連結。方便用瀏覽器或 curl 驗證索引與搜尋結果。 |
-| `GET /cag/:question` | 以同一份 R2 索引取回多段 SayIt 來源，組成 CAG prompt，呼叫 Cloudflare Workers AI（預設 Kimi K2.6），並串流 Markdown 回答與 `archive.tw#s...` footnote。 |
+| `GET /cag/status` | 顯示 CAG retriever、archive base URL、模型與 top-k 上限。 |
+| `GET /cag/:question` | 從 `archive.tw/api/search.json` 找相關段落，再用 `/api/section/:id` 取回前後文，組成 CAG prompt，呼叫 Cloudflare Workers AI（預設 Kimi K2.6），並串流 Markdown 回答與 `archive.tw#s...` footnote。 |
 | `POST /cag` | JSON 版本的 CAG endpoint：`{ "question": "...", "topK": 6 }`，同樣串流 Markdown。 |
 | `POST /webhook` | LINE Messaging API webhook。收到 LINE 文字訊息後，使用與 `/ask/:question` 相同的搜尋 pipeline，並以 Flex Message 回覆最相近段落、出處、日期與原文連結。 |
 
@@ -85,12 +86,6 @@ npx wrangler r2 bucket create askit-fuse-index-cache-preview
 npm run build:index
 ```
 
-長 lore / CAG 用的索引會保留更長段落、往回抓 30 年：
-
-```bash
-npm run build:index:lore
-```
-
 可用環境變數覆蓋：
 
 | 變數 | 預設 | 說明 |
@@ -100,8 +95,8 @@ npm run build:index:lore
 | `R2_BUCKET` | `askit-fuse-index-cache` | 上傳到的 R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 物件 key |
 | `R2_MANIFEST_KEY` | `ask-index/audrey-tang.manifest.json` | 小型 sidecar manifest key，會在索引 JSON 上傳成功後才上傳 |
-| `MAX_SECTION_CHARS` | `100` | 只保留純文字長度不超過此值的段落；`build:index:lore` 設為 `2200` |
-| `YEARS_BACK` | `2` | 只保留最近幾年的逐字稿；`build:index:lore` 設為 `30` |
+| `MAX_SECTION_CHARS` | `100` | 只保留純文字長度不超過此值的段落 |
+| `YEARS_BACK` | `2` | 只保留最近幾年的逐字稿 |
 | `LOCAL=1` | — | 對 D1 下 `--local`（預設 `--remote` 用線上資料庫） |
 | `SKIP_UPLOAD=1` | — | 只在 `build/` 產出 JSON 不上傳 |
 
@@ -110,8 +105,9 @@ npm run build:index:lore
 #### CAG + Workers AI
 
 `/cag/:question` 是把 DS4 CAG 實驗搬進 Cloudflare runtime 的部分：
-retrieve 仍然使用 build-time R2 Fuse index，runtime 不查 D1；生成改由 Workers AI
-binding `AI` 執行，預設模型由 `ASK_MODEL` 控制。
+retrieve 使用 `ASK_ARCHIVE_BASE_URL`（預設 `https://archive.tw`）的 `/api/search.json`
+做第一階段搜尋，再用 `/api/section/:id` 取回命中段落與前後文；生成由 Workers AI
+binding `AI` 執行，預設模型由 `ASK_MODEL` 控制。這避免把 30 年 long-lore 索引塞進 Worker isolate。
 
 ```bash
 curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
@@ -120,18 +116,18 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 輸出是 streaming Markdown。模型若輸出 `[1]` 這類來源標記，Worker 會轉成
 `[^1]` 並在結尾補上 footnote，連到對應的 `archive.tw/<speech>#s<section_id>`。
 
-#### 隨 transcript / sayit-hono 更新 CAG
+#### 隨 transcript / sayit-hono 更新
 
-本 repo 的 `.github/workflows/refresh-cag-index.yml` 提供三種入口：
+本 repo 的 `.github/workflows/refresh-cag-index.yml` 會刷新 `/ask` / LINE webhook 用的 R2 Fuse 索引；`/cag` 直接讀 `archive.tw` API，所以在 `sayit-hono` 部署成功後自然讀到新內容。workflow 提供三種入口：
 
 - `repository_dispatch` 的 `sayit-updated` event：給 `transcript` repo 在成功上傳 Markdown 並部署 `sayit-hono` 後觸發。
 - `workflow_dispatch`：手動重建索引；可勾選 `deploy` 讓 Worker 也一起部署，作為立即 cache reset。
 - 每日 schedule：漏掉 dispatch 時的保底。
 
-建議在 `transcript` repo 的 `Sync markdown on push` workflow、`rebuild-search-index` job 成功部署 `sayit-hono` 後加上：
+建議在 `transcript` repo 的 `Sync markdown on push` workflow、`rebuild-search-index` job 成功部署 `sayit-hono` 後加上，讓 `/ask` 與 LINE 索引也跟著更新：
 
 ```yaml
-- name: Refresh AskIt CAG index
+- name: Refresh AskIt index
   env:
     GH_TOKEN: ${{ secrets.ASKIT_REBUILD_TOKEN }}
   run: |
@@ -140,7 +136,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
       -F client_payload[transcript_sha]="${GITHUB_SHA}"
 ```
 
-`ASKIT_REBUILD_TOKEN` 需要能對 `bestian/askit-hono` 發送 repository dispatch；細粒度 PAT 可給該 repo `Contents: read/write` 權限。dispatch 進來後，askit-hono workflow 會 `npm run build:index:lore` 上傳新的 R2 索引與 manifest，然後 dry-run 驗證 Worker bundle。線上 Worker 最多在約一分鐘內看到 manifest 變更並重載 index；部署只保留為手動 cache reset。
+`ASKIT_REBUILD_TOKEN` 需要能對 `bestian/askit-hono` 發送 repository dispatch；細粒度 PAT 可給該 repo `Contents: read/write` 權限。dispatch 進來後，askit-hono workflow 會 `npm run build:index` 上傳新的 R2 索引與 manifest，然後 dry-run 驗證 Worker bundle。線上 Worker 最多在約一分鐘內看到 manifest 變更並重載 `/ask` index；部署只保留為手動 cache reset。
 
 #### 本機開發
 
@@ -154,7 +150,7 @@ npm run dev        # 本機 Worker + 遠端 R2 / Workers AI binding
 npm run preview    # wrangler dev --remote，整個 Worker 也跑在 Cloudflare
 ```
 
-> 注意：`ASK_INDEX` R2 binding 與 `AI` binding 在 `wrangler.jsonc` 裡設為 `remote: true`，所以本機測 `/cag` 會讀雲端 preview R2 bucket 並呼叫 Workers AI。這會用到 Cloudflare 帳號配額。若 preview bucket 還沒有索引，可先執行：
+> 注意：`ASK_INDEX` R2 binding 與 `AI` binding 在 `wrangler.jsonc` 裡設為 `remote: true`。本機測 `/ask` 會讀雲端 preview R2 bucket；本機測 `/cag` 會呼叫 `archive.tw` API 與 Workers AI。這會用到 Cloudflare 帳號配額。若 preview bucket 還沒有 `/ask` 索引，可先執行：
 
 ```bash
 npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \
@@ -309,7 +305,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 
 A LINE bot that, when a user asks a question (e.g. "Will AI control us?"), finds the closest matching paragraph from a chosen speaker's transcripts on [SayIt](https://archive.tw) (the sayit-hono project) — defaulting to **Audrey Tang** — and replies with the excerpt plus a link to the source.
 
-Built with [Hono](https://hono.dev/) on Cloudflare Workers. The Worker does **not** query D1 at runtime; instead, a build-time script pulls sections from D1, builds a [Fuse.js](https://www.fusejs.io/) index, and uploads it to R2. The Worker loads the prebuilt index from R2 on first request and runs fuzzy search against it.
+Built with [Hono](https://hono.dev/) on Cloudflare Workers. LINE `/webhook` and `/ask/:question` use a build-time R2 Fuse index. `/cag` uses `archive.tw` search and section APIs for long-lore retrieval, so the Worker does not cold-load a giant transcript index.
 
 ### Routes
 
@@ -317,7 +313,8 @@ Built with [Hono](https://hono.dev/) on Cloudflare Workers. The Worker does **no
 | --- | --- |
 | `GET /` | Healthcheck — returns `Hello World!` |
 | `GET /ask/:question` | **Temporary debug endpoint** — URL-decodes the question, runs the search, returns HTML with the closest section and a link to the source. Handy for testing from a browser or `curl`. |
-| `GET /cag/:question` | Retrieves multiple SayIt sections from the same R2 index, builds a CAG prompt, calls Cloudflare Workers AI (Kimi K2.6 by default), and streams Markdown with `archive.tw#s...` footnotes. |
+| `GET /cag/status` | Shows the CAG retriever, archive base URL, model, and top-k limit. |
+| `GET /cag/:question` | Searches `archive.tw/api/search.json`, hydrates hits through `/api/section/:id`, builds a CAG prompt, calls Cloudflare Workers AI (Kimi K2.6 by default), and streams Markdown with `archive.tw#s...` footnotes. |
 | `POST /cag` | JSON CAG endpoint: `{ "question": "...", "topK": 6 }`, also streaming Markdown. |
 | `POST /webhook` | LINE Messaging API webhook. For text messages, it uses the same search pipeline as `/ask/:question` and replies with the closest section, source, date, and source link as a Flex Message. |
 
@@ -386,12 +383,6 @@ npx wrangler r2 bucket create askit-fuse-index-cache-preview
 npm run build:index
 ```
 
-The long-lore CAG profile keeps longer sections and looks back 30 years:
-
-```bash
-npm run build:index:lore
-```
-
 Optional environment variables:
 
 | Var | Default | Notes |
@@ -401,8 +392,8 @@ Optional environment variables:
 | `R2_BUCKET` | `askit-fuse-index-cache` | Target R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 object key |
 | `R2_MANIFEST_KEY` | `ask-index/audrey-tang.manifest.json` | Tiny sidecar manifest key, uploaded only after the index JSON succeeds |
-| `MAX_SECTION_CHARS` | `100` | Keep sections whose plain-text length is at most this value; `build:index:lore` uses `2200` |
-| `YEARS_BACK` | `2` | Keep transcripts from the last N years; `build:index:lore` uses `30` |
+| `MAX_SECTION_CHARS` | `100` | Keep sections whose plain-text length is at most this value |
+| `YEARS_BACK` | `2` | Keep transcripts from the last N years |
 | `LOCAL=1` | — | Use `--local` against D1 (defaults to `--remote`) |
 | `SKIP_UPLOAD=1` | — | Write the JSON to `build/` only, skip the R2 upload |
 
@@ -411,9 +402,11 @@ Upload order is "large index JSON first, manifest second." The Worker treats the
 #### CAG + Workers AI
 
 `/cag/:question` is the Cloudflare-native slice of the DS4 CAG experiment:
-retrieval still uses the build-time R2 Fuse index, so runtime does not query D1;
-generation runs through the Workers AI `AI` binding. The default model is
-controlled by `ASK_MODEL`.
+retrieval uses `ASK_ARCHIVE_BASE_URL` (`https://archive.tw` by default) for
+`/api/search.json`, then hydrates each section through `/api/section/:id` to get
+neighbor context. Generation runs through the Workers AI `AI` binding. The
+default model is controlled by `ASK_MODEL`. This avoids loading a 30-year
+long-lore index into the Worker isolate.
 
 ```bash
 curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
@@ -423,18 +416,18 @@ The response is streaming Markdown. If the model emits source markers like
 `[1]`, the Worker rewrites them to `[^1]` and appends footnotes linked to the
 matching `archive.tw/<speech>#s<section_id>` source.
 
-#### Keeping CAG fresh after transcript pushes
+#### Keeping Transcript Updates Fresh
 
-This repo includes `.github/workflows/refresh-cag-index.yml` with three entrypoints:
+This repo includes `.github/workflows/refresh-cag-index.yml` to refresh the R2 Fuse index used by `/ask` and the LINE webhook. `/cag` reads the `archive.tw` APIs directly, so it sees new content once `sayit-hono` deploys. The workflow has three entrypoints:
 
 - `repository_dispatch` event `sayit-updated`: intended for the `transcript` repo after Markdown upload and `sayit-hono` deploy succeed.
 - `workflow_dispatch`: manual index refresh; set `deploy=true` to deploy the Worker too as an immediate cache reset.
 - Daily schedule: a backstop if a dispatch is missed.
 
-Recommended final step in the `transcript` repo's `Sync markdown on push` workflow, after the `rebuild-search-index` job deploys `sayit-hono`:
+Recommended final step in the `transcript` repo's `Sync markdown on push` workflow, after the `rebuild-search-index` job deploys `sayit-hono`, so `/ask` and LINE stay fresh too:
 
 ```yaml
-- name: Refresh AskIt CAG index
+- name: Refresh AskIt index
   env:
     GH_TOKEN: ${{ secrets.ASKIT_REBUILD_TOKEN }}
   run: |
@@ -443,7 +436,7 @@ Recommended final step in the `transcript` repo's `Sync markdown on push` workfl
       -F client_payload[transcript_sha]="${GITHUB_SHA}"
 ```
 
-`ASKIT_REBUILD_TOKEN` must be able to send repository dispatches to `bestian/askit-hono`; a fine-grained PAT with `Contents: read/write` for that repo works. Once the dispatch arrives, askit-hono runs `npm run build:index:lore`, uploads the refreshed R2 index and manifest, then dry-run validates the Worker bundle. The live Worker sees the manifest change and reloads the index within roughly one minute; deploy is kept only as a manual cache reset.
+`ASKIT_REBUILD_TOKEN` must be able to send repository dispatches to `bestian/askit-hono`; a fine-grained PAT with `Contents: read/write` for that repo works. Once the dispatch arrives, askit-hono runs `npm run build:index`, uploads the refreshed R2 index and manifest, then dry-run validates the Worker bundle. The live Worker sees the manifest change and reloads the `/ask` index within roughly one minute; deploy is kept only as a manual cache reset.
 
 #### Run locally
 
@@ -457,7 +450,7 @@ npm run dev        # local Worker + remote R2 / Workers AI bindings
 npm run preview    # wrangler dev --remote — the Worker itself also runs on Cloudflare
 ```
 
-> Note: `ASK_INDEX` and `AI` are marked `remote: true` in `wrangler.jsonc`, so local `/cag` tests read the cloud preview R2 bucket and call Workers AI. That uses your Cloudflare account quota. If the preview bucket does not have an index yet, seed it first:
+> Note: `ASK_INDEX` and `AI` are marked `remote: true` in `wrangler.jsonc`. Local `/ask` tests read the cloud preview R2 bucket; local `/cag` tests call `archive.tw` APIs and Workers AI. That uses your Cloudflare account quota. If the preview bucket does not have the `/ask` index yet, seed it first:
 
 ```bash
 npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ speakers.name LIKE ─┤  (scripts/build-ask-index.ts)
    R2: askit-fuse-index-cache/ask-index/audrey-tang.json
 ```
 
-Worker 端 `src/utils/search.ts` 第一次請求時從 R2 抓索引、用 `Fuse.parseIndex` 還原，之後同個 isolate 都共用。索引更新只要重跑 `npm run build:index`，不需要 redeploy worker（但已存在的 isolate 還會用 cache，最多等到自然回收）。
+Worker 端 `src/utils/search.ts` 第一次請求時從 R2 抓索引、用 `Fuse.parseIndex` 還原，之後同個 isolate 都共用。一般索引更新只要重跑 `npm run build:index`；若要讓 CAG 立刻讀到最新索引，重建 R2 物件後也部署一次 Worker，讓 runtime cache 一起刷新。
 
 ### 專案結構
 
@@ -85,14 +85,22 @@ npx wrangler r2 bucket create askit-fuse-index-cache-preview
 npm run build:index
 ```
 
+長 lore / CAG 用的索引會保留更長段落、往回抓 30 年：
+
+```bash
+npm run build:index:lore
+```
+
 可用環境變數覆蓋：
 
 | 變數 | 預設 | 說明 |
 | --- | --- | --- |
 | `D1_DATABASE` | `sayit-database` | D1 資料庫名稱（要與 sayit-hono 相同） |
 | `SPEAKER_LIKE` | `唐鳳%` | `speakers.name LIKE` 條件 |
-| `R2_BUCKET` | `askit-fuse-index-cache-preview` | 上傳到的 R2 bucket |
+| `R2_BUCKET` | `askit-fuse-index-cache` | 上傳到的 R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 物件 key |
+| `MAX_SECTION_CHARS` | `100` | 只保留純文字長度不超過此值的段落；`build:index:lore` 設為 `2200` |
+| `YEARS_BACK` | `2` | 只保留最近幾年的逐字稿；`build:index:lore` 設為 `30` |
 | `LOCAL=1` | — | 對 D1 下 `--local`（預設 `--remote` 用線上資料庫） |
 | `SKIP_UPLOAD=1` | — | 只在 `build/` 產出 JSON 不上傳 |
 
@@ -109,6 +117,28 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 輸出是 streaming Markdown。模型若輸出 `[1]` 這類來源標記，Worker 會轉成
 `[^1]` 並在結尾補上 footnote，連到對應的 `archive.tw/<speech>#s<section_id>`。
 
+#### 隨 transcript / sayit-hono 更新 CAG
+
+本 repo 的 `.github/workflows/refresh-cag-index.yml` 提供三種入口：
+
+- `repository_dispatch` 的 `sayit-updated` event：給 `transcript` repo 在成功上傳 Markdown 並部署 `sayit-hono` 後觸發。
+- `workflow_dispatch`：手動重建索引；可勾選 `deploy` 讓 Worker 也一起部署，刷新 isolate cache。
+- 每日 schedule：漏掉 dispatch 時的保底。
+
+建議在 `transcript` repo 的 `Sync markdown on push` workflow、`rebuild-search-index` job 成功部署 `sayit-hono` 後加上：
+
+```yaml
+- name: Refresh AskIt CAG index
+  env:
+    GH_TOKEN: ${{ secrets.ASKIT_REBUILD_TOKEN }}
+  run: |
+    gh api repos/bestian/askit-hono/dispatches \
+      -f event_type=sayit-updated \
+      -F client_payload[transcript_sha]="${GITHUB_SHA}"
+```
+
+`ASKIT_REBUILD_TOKEN` 需要能對 `bestian/askit-hono` 發送 repository dispatch；細粒度 PAT 可給該 repo `Contents: read/write` 權限。dispatch 進來後，askit-hono workflow 會 `npm run build:index:lore` 上傳新的 R2 索引，dry-run 驗證 Worker bundle，最後部署 Worker 以刷新 runtime cache。
+
 #### 本機開發
 
 前置作業：建立 `.dev.vars` 並填入 LINE 的 Channel access token 與 Channel secret（[詳細說明](#兩個必要的-secret)）。
@@ -117,11 +147,18 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 cp .dev.vars.example .dev.vars
 # 編輯 .dev.vars，填入實際值
 
-npm run dev        # 本地 R2 模擬（你需要事先把索引匯入本地）
-npm run preview    # wrangler dev --remote，連到雲端 R2 實際索引（推薦）
+npm run dev        # 本機 Worker + 遠端 R2 / Workers AI binding
+npm run preview    # wrangler dev --remote，整個 Worker 也跑在 Cloudflare
 ```
 
-> 注意：`npm run dev` 走 miniflare 本地 R2 模擬，剛上傳的雲端索引在這裡讀不到，會回 `404 找不到 R2 物件`。要真的測搜尋請用 `npm run preview`。
+> 注意：`ASK_INDEX` R2 binding 與 `AI` binding 在 `wrangler.jsonc` 裡設為 `remote: true`，所以本機測 `/cag` 會讀雲端 preview R2 bucket 並呼叫 Workers AI。這會用到 Cloudflare 帳號配額。若 preview bucket 還沒有索引，可先執行：
+
+```bash
+npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \
+  --file build/audrey-tang.json \
+  --content-type 'application/json; charset=utf-8' \
+  --remote
+```
 
 開發時可用 `/ask/:question` 直接以瀏覽器或 curl 測：
 
@@ -244,10 +281,16 @@ curl -X POST https://YOUR-WORKER-URL/webhook \
 curl 'https://YOUR-WORKER-URL/ask/AI%E6%9C%83%E4%B8%8D%E6%9C%83%E6%8E%A7%E5%88%B6%E6%88%91%E5%80%91'
 ```
 
+CAG 串流可用：
+
+```bash
+curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
+```
+
 ### 已知議題 / TODO
 
 - **索引大小**：當前 `唐鳳%` 範圍下索引約 75 MB（105k 段落）。Workers isolate 記憶體上限 128MB，第一次 `JSON.parse` + `Fuse.parseIndex` 會吃不少；後續可能需要瘦身（拿掉 runtime 用不到的欄位、縮短 key 名、或分片）。
-- **isolate cache 不會自動失效**：`npm run build:index` 上傳後，已存在的 Worker isolate 還是用舊 cache，要等到自然回收。需要強制刷新可以加一條 admin 路由清掉 module-level cache，或部署時順便刷新。
+- **isolate cache 不會自動失效**：`npm run build:index` 上傳後，已存在的 Worker isolate 還是用舊 cache，要等到自然回收。`refresh-cag-index.yml` 的 dispatch 路徑會在更新 R2 後部署 Worker，作為目前的刷新機制。
 
 ### 授權
 
@@ -292,7 +335,7 @@ speakers.name LIKE ─┤  (scripts/build-ask-index.ts)
    R2: askit-fuse-index-cache/ask-index/audrey-tang.json
 ```
 
-On first request, the Worker reads the index from R2 and rehydrates it via `Fuse.parseIndex`. The parsed index is cached at module scope so subsequent requests in the same isolate skip the load. To refresh, just rerun `npm run build:index` — no redeploy needed (existing isolates keep the old cache until they recycle).
+On first request, the Worker reads the index from R2 and rehydrates it via `Fuse.parseIndex`. The parsed index is cached at module scope so subsequent requests in the same isolate skip the load. A normal refresh only needs `npm run build:index`; for CAG freshness, rebuild the R2 object and deploy the Worker once so runtime caches roll forward immediately.
 
 ### Project structure
 
@@ -336,14 +379,22 @@ npx wrangler r2 bucket create askit-fuse-index-cache-preview
 npm run build:index
 ```
 
+The long-lore CAG profile keeps longer sections and looks back 30 years:
+
+```bash
+npm run build:index:lore
+```
+
 Optional environment variables:
 
 | Var | Default | Notes |
 | --- | --- | --- |
 | `D1_DATABASE` | `sayit-database` | D1 database name (must match sayit-hono) |
 | `SPEAKER_LIKE` | `唐鳳%` | `speakers.name LIKE` condition |
-| `R2_BUCKET` | `askit-fuse-index-cache-preview` | Target R2 bucket |
+| `R2_BUCKET` | `askit-fuse-index-cache` | Target R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 object key |
+| `MAX_SECTION_CHARS` | `100` | Keep sections whose plain-text length is at most this value; `build:index:lore` uses `2200` |
+| `YEARS_BACK` | `2` | Keep transcripts from the last N years; `build:index:lore` uses `30` |
 | `LOCAL=1` | — | Use `--local` against D1 (defaults to `--remote`) |
 | `SKIP_UPLOAD=1` | — | Write the JSON to `build/` only, skip the R2 upload |
 
@@ -362,6 +413,28 @@ The response is streaming Markdown. If the model emits source markers like
 `[1]`, the Worker rewrites them to `[^1]` and appends footnotes linked to the
 matching `archive.tw/<speech>#s<section_id>` source.
 
+#### Keeping CAG fresh after transcript pushes
+
+This repo includes `.github/workflows/refresh-cag-index.yml` with three entrypoints:
+
+- `repository_dispatch` event `sayit-updated`: intended for the `transcript` repo after Markdown upload and `sayit-hono` deploy succeed.
+- `workflow_dispatch`: manual index refresh; set `deploy=true` to deploy the Worker too and flush isolate caches.
+- Daily schedule: a backstop if a dispatch is missed.
+
+Recommended final step in the `transcript` repo's `Sync markdown on push` workflow, after the `rebuild-search-index` job deploys `sayit-hono`:
+
+```yaml
+- name: Refresh AskIt CAG index
+  env:
+    GH_TOKEN: ${{ secrets.ASKIT_REBUILD_TOKEN }}
+  run: |
+    gh api repos/bestian/askit-hono/dispatches \
+      -f event_type=sayit-updated \
+      -F client_payload[transcript_sha]="${GITHUB_SHA}"
+```
+
+`ASKIT_REBUILD_TOKEN` must be able to send repository dispatches to `bestian/askit-hono`; a fine-grained PAT with `Contents: read/write` for that repo works. Once the dispatch arrives, askit-hono runs `npm run build:index:lore`, uploads the refreshed R2 index, dry-run validates the Worker bundle, then deploys the Worker to refresh the runtime cache.
+
 #### Run locally
 
 Prerequisite: create `.dev.vars` with your LINE channel access token and channel secret (see [Two required secrets](#two-required-secrets)).
@@ -370,11 +443,18 @@ Prerequisite: create `.dev.vars` with your LINE channel access token and channel
 cp .dev.vars.example .dev.vars
 # Edit .dev.vars and paste real values
 
-npm run dev        # local R2 mock (you would need to seed it locally)
-npm run preview    # wrangler dev --remote — talks to the real R2 (recommended)
+npm run dev        # local Worker + remote R2 / Workers AI bindings
+npm run preview    # wrangler dev --remote — the Worker itself also runs on Cloudflare
 ```
 
-> Note: `npm run dev` uses miniflare's local R2 emulator; the index you uploaded to the cloud bucket is not visible there and you'll see `404 R2 object not found`. Use `npm run preview` to actually exercise the search.
+> Note: `ASK_INDEX` and `AI` are marked `remote: true` in `wrangler.jsonc`, so local `/cag` tests read the cloud preview R2 bucket and call Workers AI. That uses your Cloudflare account quota. If the preview bucket does not have an index yet, seed it first:
+
+```bash
+npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \
+  --file build/audrey-tang.json \
+  --content-type 'application/json; charset=utf-8' \
+  --remote
+```
 
 You can hit `/ask/:question` directly while developing:
 
@@ -497,10 +577,16 @@ You can also exercise the search directly:
 curl 'https://YOUR-WORKER-URL/ask/AI%E6%9C%83%E4%B8%8D%E6%9C%83%E6%8E%A7%E5%88%B6%E6%88%91%E5%80%91'
 ```
 
+Streaming CAG test:
+
+```bash
+curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%EF%BC%9A%E5%9C%B0%E7%A5%9E%E9%A6%99%E7%81%AB%E5%A6%82%E4%BD%95?top_k=6'
+```
+
 ### Known issues / TODO
 
 - **Index size.** The default `唐鳳%` range produces ~75 MB (~105k sections). Workers isolates have a 128 MB memory limit, so the first `JSON.parse` + `Fuse.parseIndex` is a meaningful cost. We may need to slim the payload (drop unused fields, shorter keys, or shard) once it actually starts hitting the ceiling.
-- **Module-level cache doesn't auto-invalidate.** After `npm run build:index` re-uploads, existing isolates keep serving from the in-memory cache until they recycle. If you need an immediate flush, expose an admin route that clears the module cache, or refresh on deploy.
+- **Module-level cache doesn't auto-invalidate.** After `npm run build:index` re-uploads, existing isolates keep serving from the in-memory cache until they recycle. The dispatch path in `refresh-cag-index.yml` deploys the Worker after updating R2 and uses that as the current flush mechanism.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ speakers.name LIKE ─┤  (scripts/build-ask-index.ts)
    R2: askit-fuse-index-cache/ask-index/audrey-tang.json
 ```
 
-Worker 端 `src/utils/search.ts` 第一次請求時從 R2 抓索引、用 `Fuse.parseIndex` 還原，之後同個 isolate 都共用。一般索引更新只要重跑 `npm run build:index`；若要讓 CAG 立刻讀到最新索引，重建 R2 物件後也部署一次 Worker，讓 runtime cache 一起刷新。
+Worker 端 `src/utils/search.ts` 第一次請求時從 R2 抓索引、用 `Fuse.parseIndex` 還原，之後同個 isolate 都共用。build script 也會上傳一個很小的 manifest sidecar（預設 `ask-index/audrey-tang.manifest.json`）；Worker 會定期讀 manifest，發現 `indexSha256` 變更時自動重載大索引，不需要每次 transcript 更新都 redeploy。
 
 ### 專案結構
 
@@ -99,10 +99,13 @@ npm run build:index:lore
 | `SPEAKER_LIKE` | `唐鳳%` | `speakers.name LIKE` 條件 |
 | `R2_BUCKET` | `askit-fuse-index-cache` | 上傳到的 R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 物件 key |
+| `R2_MANIFEST_KEY` | `ask-index/audrey-tang.manifest.json` | 小型 sidecar manifest key，會在索引 JSON 上傳成功後才上傳 |
 | `MAX_SECTION_CHARS` | `100` | 只保留純文字長度不超過此值的段落；`build:index:lore` 設為 `2200` |
 | `YEARS_BACK` | `2` | 只保留最近幾年的逐字稿；`build:index:lore` 設為 `30` |
 | `LOCAL=1` | — | 對 D1 下 `--local`（預設 `--remote` 用線上資料庫） |
 | `SKIP_UPLOAD=1` | — | 只在 `build/` 產出 JSON 不上傳 |
+
+上傳順序是「大索引 JSON 先、manifest 後」。Worker 只把 manifest 當作版本訊號，所以不會在 R2 還沒拿到新索引時切換。
 
 #### CAG + Workers AI
 
@@ -122,7 +125,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 本 repo 的 `.github/workflows/refresh-cag-index.yml` 提供三種入口：
 
 - `repository_dispatch` 的 `sayit-updated` event：給 `transcript` repo 在成功上傳 Markdown 並部署 `sayit-hono` 後觸發。
-- `workflow_dispatch`：手動重建索引；可勾選 `deploy` 讓 Worker 也一起部署，刷新 isolate cache。
+- `workflow_dispatch`：手動重建索引；可勾選 `deploy` 讓 Worker 也一起部署，作為立即 cache reset。
 - 每日 schedule：漏掉 dispatch 時的保底。
 
 建議在 `transcript` repo 的 `Sync markdown on push` workflow、`rebuild-search-index` job 成功部署 `sayit-hono` 後加上：
@@ -137,7 +140,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
       -F client_payload[transcript_sha]="${GITHUB_SHA}"
 ```
 
-`ASKIT_REBUILD_TOKEN` 需要能對 `bestian/askit-hono` 發送 repository dispatch；細粒度 PAT 可給該 repo `Contents: read/write` 權限。dispatch 進來後，askit-hono workflow 會 `npm run build:index:lore` 上傳新的 R2 索引，dry-run 驗證 Worker bundle，最後部署 Worker 以刷新 runtime cache。
+`ASKIT_REBUILD_TOKEN` 需要能對 `bestian/askit-hono` 發送 repository dispatch；細粒度 PAT 可給該 repo `Contents: read/write` 權限。dispatch 進來後，askit-hono workflow 會 `npm run build:index:lore` 上傳新的 R2 索引與 manifest，然後 dry-run 驗證 Worker bundle。線上 Worker 最多在約一分鐘內看到 manifest 變更並重載 index；部署只保留為手動 cache reset。
 
 #### 本機開發
 
@@ -156,6 +159,10 @@ npm run preview    # wrangler dev --remote，整個 Worker 也跑在 Cloudflare
 ```bash
 npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \
   --file build/audrey-tang.json \
+  --content-type 'application/json; charset=utf-8' \
+  --remote
+npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.manifest.json' \
+  --file build/audrey-tang.manifest.json \
   --content-type 'application/json; charset=utf-8' \
   --remote
 ```
@@ -290,7 +297,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 ### 已知議題 / TODO
 
 - **索引大小**：當前 `唐鳳%` 範圍下索引約 75 MB（105k 段落）。Workers isolate 記憶體上限 128MB，第一次 `JSON.parse` + `Fuse.parseIndex` 會吃不少；後續可能需要瘦身（拿掉 runtime 用不到的欄位、縮短 key 名、或分片）。
-- **isolate cache 不會自動失效**：`npm run build:index` 上傳後，已存在的 Worker isolate 還是用舊 cache，要等到自然回收。`refresh-cag-index.yml` 的 dispatch 路徑會在更新 R2 後部署 Worker，作為目前的刷新機制。
+- **manifest 輪詢不是瞬間同步**：`npm run build:index` 上傳後，已存在的 Worker isolate 最多等約一分鐘才會看到 manifest 變更並重載 index。需要立刻刷新時，可手動跑 workflow 並勾選 `deploy`。
 
 ### 授權
 
@@ -335,7 +342,7 @@ speakers.name LIKE ─┤  (scripts/build-ask-index.ts)
    R2: askit-fuse-index-cache/ask-index/audrey-tang.json
 ```
 
-On first request, the Worker reads the index from R2 and rehydrates it via `Fuse.parseIndex`. The parsed index is cached at module scope so subsequent requests in the same isolate skip the load. A normal refresh only needs `npm run build:index`; for CAG freshness, rebuild the R2 object and deploy the Worker once so runtime caches roll forward immediately.
+On first request, the Worker reads the index from R2 and rehydrates it via `Fuse.parseIndex`. The parsed index is cached at module scope so subsequent requests in the same isolate skip the load. The build script also uploads a tiny manifest sidecar, defaulting to `ask-index/audrey-tang.manifest.json`; the Worker periodically reads that manifest and reloads the large index when `indexSha256` changes, so transcript refreshes do not require a Worker redeploy.
 
 ### Project structure
 
@@ -393,10 +400,13 @@ Optional environment variables:
 | `SPEAKER_LIKE` | `唐鳳%` | `speakers.name LIKE` condition |
 | `R2_BUCKET` | `askit-fuse-index-cache` | Target R2 bucket |
 | `R2_KEY` | `ask-index/audrey-tang.json` | R2 object key |
+| `R2_MANIFEST_KEY` | `ask-index/audrey-tang.manifest.json` | Tiny sidecar manifest key, uploaded only after the index JSON succeeds |
 | `MAX_SECTION_CHARS` | `100` | Keep sections whose plain-text length is at most this value; `build:index:lore` uses `2200` |
 | `YEARS_BACK` | `2` | Keep transcripts from the last N years; `build:index:lore` uses `30` |
 | `LOCAL=1` | — | Use `--local` against D1 (defaults to `--remote`) |
 | `SKIP_UPLOAD=1` | — | Write the JSON to `build/` only, skip the R2 upload |
+
+Upload order is "large index JSON first, manifest second." The Worker treats the manifest as the version signal, so it does not switch before R2 has the new index object.
 
 #### CAG + Workers AI
 
@@ -418,7 +428,7 @@ matching `archive.tw/<speech>#s<section_id>` source.
 This repo includes `.github/workflows/refresh-cag-index.yml` with three entrypoints:
 
 - `repository_dispatch` event `sayit-updated`: intended for the `transcript` repo after Markdown upload and `sayit-hono` deploy succeed.
-- `workflow_dispatch`: manual index refresh; set `deploy=true` to deploy the Worker too and flush isolate caches.
+- `workflow_dispatch`: manual index refresh; set `deploy=true` to deploy the Worker too as an immediate cache reset.
 - Daily schedule: a backstop if a dispatch is missed.
 
 Recommended final step in the `transcript` repo's `Sync markdown on push` workflow, after the `rebuild-search-index` job deploys `sayit-hono`:
@@ -433,7 +443,7 @@ Recommended final step in the `transcript` repo's `Sync markdown on push` workfl
       -F client_payload[transcript_sha]="${GITHUB_SHA}"
 ```
 
-`ASKIT_REBUILD_TOKEN` must be able to send repository dispatches to `bestian/askit-hono`; a fine-grained PAT with `Contents: read/write` for that repo works. Once the dispatch arrives, askit-hono runs `npm run build:index:lore`, uploads the refreshed R2 index, dry-run validates the Worker bundle, then deploys the Worker to refresh the runtime cache.
+`ASKIT_REBUILD_TOKEN` must be able to send repository dispatches to `bestian/askit-hono`; a fine-grained PAT with `Contents: read/write` for that repo works. Once the dispatch arrives, askit-hono runs `npm run build:index:lore`, uploads the refreshed R2 index and manifest, then dry-run validates the Worker bundle. The live Worker sees the manifest change and reloads the index within roughly one minute; deploy is kept only as a manual cache reset.
 
 #### Run locally
 
@@ -452,6 +462,10 @@ npm run preview    # wrangler dev --remote — the Worker itself also runs on Cl
 ```bash
 npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.json' \
   --file build/audrey-tang.json \
+  --content-type 'application/json; charset=utf-8' \
+  --remote
+npx wrangler r2 object put 'askit-fuse-index-cache-preview/ask-index/audrey-tang.manifest.json' \
+  --file build/audrey-tang.manifest.json \
   --content-type 'application/json; charset=utf-8' \
   --remote
 ```
@@ -586,7 +600,7 @@ curl -N 'https://YOUR-WORKER-URL/cag/%E7%94%A8%20%23zh-tw%20%E5%9B%9E%E7%AD%94%E
 ### Known issues / TODO
 
 - **Index size.** The default `唐鳳%` range produces ~75 MB (~105k sections). Workers isolates have a 128 MB memory limit, so the first `JSON.parse` + `Fuse.parseIndex` is a meaningful cost. We may need to slim the payload (drop unused fields, shorter keys, or shard) once it actually starts hitting the ceiling.
-- **Module-level cache doesn't auto-invalidate.** After `npm run build:index` re-uploads, existing isolates keep serving from the in-memory cache until they recycle. The dispatch path in `refresh-cag-index.yml` deploys the Worker after updating R2 and uses that as the current flush mechanism.
+- **Manifest polling is not instant.** After `npm run build:index` re-uploads, existing isolates can take roughly one minute to see the manifest change and reload the index. For immediate reset, run the manual workflow with `deploy=true`.
 
 ### License
 

--- a/design/CAG-system-design.md
+++ b/design/CAG-system-design.md
@@ -1,0 +1,150 @@
+# CAG 系統設計（PR #12）
+
+> 對應 PR #12「[codex] add Workers AI CAG and refresh workflow」與最新 4 筆 commit。
+> 本文說明在既有 `/ask` 搜尋之上新增的 **CAG（Cited / Context-Augmented Generation）** 端點，
+> 以及支撐它的 R2 索引建置與自動刷新機制。
+
+---
+
+## 1. 這次變更解決什麼問題
+
+既有的 `/ask/:question` 只能回傳「最相近的單一逐字稿段落」（fuzzy match），
+無法把多段落整合成一段帶引註的答覆。PR #12 在不動到原本搜尋的前提下，加入：
+
+1. **`/cag/:question`** — 從 archive.tw 檢索多段逐字稿，交給 Cloudflare Workers AI（Kimi K2.6）
+   生成「**只根據引文作答 + 自動補上 `[^n]` 註腳**」的串流 Markdown 回覆。
+2. **R2 索引的自動刷新流程** — 讓 `/ask` 用的 Fuse 索引能在上游 SayIt 更新時自動重建，
+   並透過 manifest sidecar 讓執行中的 Worker 偵測到變更、熱重載。
+3. **生產環境硬化** — 查詢變體、輸入夾限、錯誤降級、CI 與測試。
+
+---
+
+## 2. 四筆 Commit 的演進
+
+| # | Commit | 做了什麼 | 主要檔案 |
+|---|--------|----------|----------|
+| 1 | `fa8370f` add Workers AI CAG endpoint | 新增 `src/utils/cag.ts` 與 `/cag/:question`、`POST /cag`，接上 `AI` binding；archive.tw 檢索 + Workers AI 串流 | `cag.ts`, `index.ts`, `wrangler.jsonc` |
+| 2 | `4891e2d` automate CAG index refresh | 新增 `refresh-cag-index.yml`：`workflow_dispatch` / `repository_dispatch(sayit-updated)` / 每日 cron 觸發 `build:index` | `refresh-cag-index.yml`, `package.json` |
+| 3 | `9b4f600` add R2 manifest refresh for CAG index | 為索引加上 **manifest sidecar**（sha256/generatedAt/rowCount），`search.ts` 以 fingerprint 做快取失效與熱重載 | `askIndexFormat.ts`, `search.ts`, `build-ask-index.ts` |
+| 4 | `9fef755` make CAG retrieval production safe | 查詢變體、整數夾限、抓取失敗降級、`robots.txt` 擋 `/cag/`、CI workflow、`test/cag.test.ts` | `cag.ts`, `ci.yml`, `index.ts`, `test/` |
+
+> 演進邏輯：**先能跑（1）→ 索引能自動更新（2）→ 執行期能偵測更新（3）→ 上線安全（4）**。
+
+---
+
+## 3. 執行期架構（請求 → 回覆）
+
+### 3.1 路由層 `src/index.ts`（Hono）
+
+| 路由 | 用途 | 後端 |
+|------|------|------|
+| `GET /ask/:question` | 既有：單段落 fuzzy 命中（支援「隨機 / random」） | R2 Fuse 索引 |
+| `POST /webhook` | LINE bot：簽章驗證 → 同 `/ask` 搜尋 → Flex 訊息 | R2 Fuse 索引 |
+| `GET /cag/:question` | **新增**：串流 CAG 答覆（`top_k`、`max_tokens`、`model` query） | archive.tw + Workers AI |
+| `POST /cag` | **新增**：JSON body 版本的 CAG | archive.tw + Workers AI |
+| `GET /cag/status` | **新增**：回報 retriever / model / 上限設定 | — |
+| `GET /robots.txt` | 擋爬 `/ask/`、`/cag/`、`/webhook` | — |
+
+### 3.2 CAG 管線 `src/utils/cag.ts` — `streamCagAnswer()`
+
+```
+question
+  │
+  ▼  retrieveCagSources()
+  ├─ buildCagQueryVariants()    把問題拆成多個檢索變體
+  │     • 去除 #directives、問句詞（如何/什麼…）
+  │     • 中文 2-gram 切詞 + 拉丁 token，最多 6 個變體
+  │
+  ├─ searchArchive() ×N         對 archive.tw /api/search.json 平行查詢，依 url 去重
+  │
+  ├─ hydrateArchiveSection()    解析 #s<id> → /api/section/:id
+  │     • 取 previous_content + section_content + next_content
+  │     • htmlToPlainText 清洗，組出 label（標題 — 講者）
+  │
+  ▼  CagSource[]（截到 topK；空集合 → 404「找不到符合條件的逐字稿段落」）
+  │
+  ▼  buildCagMessages()         system：只用引文作答、用 [n] 標註、中文用繁中
+  │                             user：<lore> 多段引文 </lore> + Question
+  │
+  ▼  ai.run('@cf/moonshotai/kimi-k2.6', { messages, stream:true,
+  │          max_completion_tokens(夾限 1..4096), temperature:0.2,
+  │          chat_template_kwargs:{ thinking:false } })   ← 關閉思考，加快可見串流
+  │
+  ▼  ReadableStream 經三段 TransformStream pipe：
+  │   1. workersAiEventStreamToText()  解析 SSE（data: …），抽出文字增量
+  │   2. markdownCitationFootnotes()   把 [1] 即時改寫成 [^1]，結尾補 [^n]: <連結>
+  │   3. TextEncoderStream             轉回 bytes
+  │
+  ▼  Response  Content-Type: text/markdown; charset=UTF-8
+              Cache-Control: no-store, X-Accel-Buffering: no（不緩衝、邊生成邊送）
+```
+
+**關鍵設計點**
+
+- **CAG 不碰 R2 Fuse 索引**：它直接打 archive.tw 公開 API 即時檢索，因此涵蓋面比 `/ask` 用的
+  「最近 2 年、≤100 字段落」索引更廣（PR 內稱 long-lore profile）。
+- **引註是串流安全的**：`markdownCitationFootnotes` 是字元狀態機，邊收串流邊把 `[n]` 轉 `[^n]`，
+  只在 flush 時輸出實際被引用到的註腳定義，避免列出沒用到的來源。
+- **輸入全部夾限**：`clampInteger` 把 `topK`（1..12）、`maxCompletionTokens`（1..4096）限制在安全範圍。
+
+---
+
+## 4. R2 索引：建置與自動刷新
+
+`/ask` 與 LINE webhook 使用預先建好的 Fuse.js 索引（執行期 **不碰 D1**）。
+
+### 4.1 建置 `scripts/build-ask-index.ts`（`npm run build:index`）
+
+```
+wrangler d1 execute sayit-database --remote
+  → SELECT … FROM sections WHERE name LIKE '唐鳳%'
+      AND 最近 YEARS_BACK 年、section_content 非空
+  → 過濾純文字長度 ≤ MAX_SECTION_CHARS
+  → Fuse.createIndex(['section_content'], rows)
+  → 產出兩個檔：
+      • audrey-tang.json           （payload：rows + Fuse index）
+      • audrey-tang.manifest.json  （sidecar：sha256 / generatedAt / rowCount …）
+  → wrangler r2 object put …（index + manifest，皆上傳 R2）
+```
+
+### 4.2 執行期熱重載 `src/utils/search.ts` — `getIndex()`
+
+- **模組層快取**：同一個 Worker isolate 跨請求共用解析後的 Fuse 物件。
+- **小 manifest 輪詢**：每 `INDEX_MANIFEST_CHECK_MS`（60 秒）才去讀很小的 manifest，
+  用 `fingerprint = sha256:generatedAt:rowCount` 比對；**只有指紋變了才重新下載大 index**。
+- **失敗降級**：manifest 或 index 重載失敗時，沿用既有 cache，不讓搜尋整個掛掉。
+
+### 4.3 自動刷新 `.github/workflows/refresh-cag-index.yml`
+
+三種觸發：
+
+1. `repository_dispatch: sayit-updated` — 上游 SayIt / sayit-hono 內容更新時主動派工。
+2. `schedule`（每日 `30 13 * * *` UTC）— 萬一上游 dispatch 漏掉的 backstop。
+3. `workflow_dispatch`（手動，可選 `deploy`）— 重建後可選擇性重新 deploy 以重置 runtime cache。
+
+流程：`npm ci → typecheck → build:index（重建並上傳 R2）→ wrangler deploy --dry-run` 驗證。
+
+---
+
+## 5. 部署綁定（`wrangler.jsonc`）
+
+| Binding | 型別 | 用途 |
+|---------|------|------|
+| `ASK_INDEX` | R2 bucket（`askit-fuse-index-cache`） | `/ask`、webhook 讀取 Fuse 索引 |
+| `AI` | Workers AI | `/cag` 呼叫 Kimi K2.6（`@cf/moonshotai/kimi-k2.6`） |
+| `ASK_MODEL` / `ASK_ARCHIVE_BASE_URL` | vars | 預設模型與 archive.tw base URL |
+| `LINE_CHANNEL_*` | secret | LINE webhook 簽章與回覆 |
+
+---
+
+## 6. 兩條資料流的對照
+
+| | `/ask`（既有） | `/cag`（PR #12 新增） |
+|---|---|---|
+| 檢索來源 | R2 預建 Fuse 索引（最近 2 年、短段落） | archive.tw 即時 API（全量、含上下文） |
+| 命中數 | 單一最佳段落 | top_k 多段（預設 6，上限 12） |
+| 生成 | 無，直接回傳原文 | Workers AI 整合多段 + 引註 |
+| 回應格式 | HTML / LINE Flex | 串流 Markdown（含 `[^n]` 註腳） |
+| 即時性 | 依索引刷新（manifest 60s 偵測） | 完全即時 |
+
+詳見同目錄的 `CAG-system-design.svg` 架構圖。

--- a/design/CAG-system-design.svg
+++ b/design/CAG-system-design.svg
@@ -1,0 +1,201 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="1080" viewBox="0 0 1180 1080" font-family="-apple-system, 'Helvetica Neue', 'PingFang TC', Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#475569"/>
+    </marker>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#059669"/>
+    </marker>
+    <style>
+      .title { font-size: 26px; font-weight: 700; fill: #0f172a; }
+      .sub { font-size: 13px; fill: #64748b; }
+      .lbl { font-size: 13px; font-weight: 700; fill: #0f172a; }
+      .txt { font-size: 12px; fill: #334155; }
+      .mono { font-size: 11.5px; font-family: 'SF Mono', Menlo, Consolas, monospace; fill: #1e293b; }
+      .edge { font-size: 11px; fill: #475569; }
+      .badge { font-size: 11px; font-weight: 700; }
+      .secT { font-size: 13px; font-weight: 700; letter-spacing: .5px; }
+    </style>
+  </defs>
+
+  <rect width="1180" height="1080" fill="#f8fafc"/>
+  <text x="40" y="48" class="title">askit-hono · CAG 系統架構 (PR #12)</text>
+  <text x="40" y="70" class="sub">/cag Workers AI 檢索增強生成 · /ask R2 Fuse 索引 · 索引自動刷新管線</text>
+
+  <!-- ===== Clients ===== -->
+  <g>
+    <rect x="120" y="100" width="200" height="56" rx="10" fill="#fff" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="220" y="125" text-anchor="middle" class="lbl">瀏覽器 / curl</text>
+    <text x="220" y="143" text-anchor="middle" class="txt">GET /ask · /cag</text>
+
+    <rect x="360" y="100" width="200" height="56" rx="10" fill="#fff" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="460" y="125" text-anchor="middle" class="lbl">LINE Platform</text>
+    <text x="460" y="143" text-anchor="middle" class="txt">POST /webhook (簽章)</text>
+  </g>
+
+  <!-- ===== Routing layer ===== -->
+  <rect x="120" y="195" width="940" height="92" rx="12" fill="#eef2ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="140" y="220" class="secT" fill="#4338ca">HONO 路由層 · src/index.ts</text>
+  <g>
+    <rect x="140" y="232" width="150" height="42" rx="8" fill="#fff" stroke="#a5b4fc"/>
+    <text x="215" y="250" text-anchor="middle" class="mono">/ask/:question</text>
+    <text x="215" y="266" text-anchor="middle" class="txt">單段落 fuzzy</text>
+
+    <rect x="300" y="232" width="150" height="42" rx="8" fill="#fff" stroke="#a5b4fc"/>
+    <text x="375" y="250" text-anchor="middle" class="mono">/webhook</text>
+    <text x="375" y="266" text-anchor="middle" class="txt">LINE Flex 回覆</text>
+
+    <rect x="600" y="232" width="180" height="42" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="690" y="250" text-anchor="middle" class="mono">/cag/:question · POST</text>
+    <text x="690" y="266" text-anchor="middle" class="txt">串流 CAG 答覆</text>
+
+    <rect x="800" y="232" width="120" height="42" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="860" y="250" text-anchor="middle" class="mono">/cag/status</text>
+    <text x="860" y="266" text-anchor="middle" class="txt">設定回報</text>
+
+    <rect x="930" y="232" width="115" height="42" rx="8" fill="#fff" stroke="#a5b4fc"/>
+    <text x="987" y="250" text-anchor="middle" class="mono">/robots.txt</text>
+    <text x="987" y="266" text-anchor="middle" class="txt">擋爬</text>
+  </g>
+
+  <!-- client -> routing edges -->
+  <line x1="220" y1="156" x2="220" y2="195" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="460" y1="156" x2="375" y2="195" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ===== Left column: Ask / Fuse flow ===== -->
+  <rect x="120" y="330" width="430" height="300" rx="12" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="140" y="356" class="secT" fill="#15803d">/ask 流程 · src/utils/search.ts (既有)</text>
+
+  <rect x="150" y="372" width="370" height="62" rx="8" fill="#fff" stroke="#86efac"/>
+  <text x="166" y="392" class="lbl">getIndex() · 模組層快取</text>
+  <text x="166" y="410" class="txt">每 60s 讀 manifest，比對 fingerprint</text>
+  <text x="166" y="426" class="mono">sha256 : generatedAt : rowCount</text>
+
+  <rect x="150" y="448" width="175" height="56" rx="8" fill="#fff" stroke="#86efac"/>
+  <text x="237" y="470" text-anchor="middle" class="lbl">Fuse.search</text>
+  <text x="237" y="488" text-anchor="middle" class="txt">最佳 1 段</text>
+
+  <rect x="345" y="448" width="175" height="56" rx="8" fill="#fff" stroke="#86efac"/>
+  <text x="432" y="470" text-anchor="middle" class="lbl">隨機 / random</text>
+  <text x="432" y="488" text-anchor="middle" class="txt">findRandomSection</text>
+
+  <rect x="150" y="518" width="370" height="56" rx="8" fill="#fff" stroke="#86efac"/>
+  <text x="166" y="540" class="lbl">輸出</text>
+  <text x="166" y="558" class="txt">HTML (/ask) · LINE Flex bubble (/webhook)</text>
+
+  <text x="335" y="606" text-anchor="middle" class="txt">執行期不碰 D1，只從 R2 讀 Fuse 索引</text>
+
+  <!-- ===== Right column: CAG flow ===== -->
+  <rect x="600" y="330" width="460" height="430" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="620" y="356" class="secT" fill="#1d4ed8">/cag 流程 · src/utils/cag.ts · streamCagAnswer()</text>
+
+  <rect x="625" y="372" width="410" height="60" rx="8" fill="#fff" stroke="#93c5fd"/>
+  <text x="641" y="392" class="lbl">① buildCagQueryVariants()</text>
+  <text x="641" y="410" class="txt">去除 #directives / 問句詞 → 中文 2-gram + 拉丁 token</text>
+  <text x="641" y="425" class="txt">最多 6 個檢索變體</text>
+
+  <rect x="625" y="444" width="410" height="60" rx="8" fill="#fff" stroke="#93c5fd"/>
+  <text x="641" y="464" class="lbl">② retrieveCagSources() → archive.tw</text>
+  <text x="641" y="482" class="mono">/api/search.json ×N (平行, 去重)</text>
+  <text x="641" y="498" class="mono">/api/section/:id → prev + content + next</text>
+
+  <rect x="625" y="516" width="410" height="52" rx="8" fill="#fff" stroke="#93c5fd"/>
+  <text x="641" y="536" class="lbl">③ buildCagMessages()</text>
+  <text x="641" y="554" class="txt">system: 只用引文作答 [n] · user: &lt;lore&gt; topK 段 &lt;/lore&gt;</text>
+
+  <rect x="625" y="580" width="410" height="58" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="1.5"/>
+  <text x="641" y="600" class="lbl">④ AI.run() · Workers AI</text>
+  <text x="641" y="618" class="mono">@cf/moonshotai/kimi-k2.6 · stream</text>
+  <text x="641" y="633" class="txt">thinking:false · temp 0.2 · max_tokens 夾限</text>
+
+  <rect x="625" y="650" width="410" height="66" rx="8" fill="#fff" stroke="#93c5fd"/>
+  <text x="641" y="670" class="lbl">⑤ 三段 TransformStream pipe</text>
+  <text x="641" y="687" class="mono">SSE→text · [n]→[^n] + 註腳 · TextEncoder</text>
+  <text x="641" y="703" class="txt">text/markdown · no-store · 邊生成邊送</text>
+
+  <text x="830" y="740" text-anchor="middle" class="txt">空集合 → 404「找不到符合條件的逐字稿段落」</text>
+
+  <!-- routing -> flows -->
+  <line x1="350" y1="287" x2="350" y2="330" stroke="#059669" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+  <line x1="745" y1="287" x2="780" y2="330" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+
+  <!-- CAG internal flow arrows -->
+  <line x1="830" y1="432" x2="830" y2="444" stroke="#2563eb" stroke-width="1.3" marker-end="url(#arrowBlue)"/>
+  <line x1="830" y1="504" x2="830" y2="516" stroke="#2563eb" stroke-width="1.3" marker-end="url(#arrowBlue)"/>
+  <line x1="830" y1="568" x2="830" y2="580" stroke="#2563eb" stroke-width="1.3" marker-end="url(#arrowBlue)"/>
+  <line x1="830" y1="638" x2="830" y2="650" stroke="#2563eb" stroke-width="1.3" marker-end="url(#arrowBlue)"/>
+
+  <!-- ask internal arrows -->
+  <line x1="335" y1="434" x2="335" y2="448" stroke="#059669" stroke-width="1.3" marker-end="url(#arrowGreen)"/>
+  <line x1="335" y1="504" x2="335" y2="518" stroke="#059669" stroke-width="1.3" marker-end="url(#arrowGreen)"/>
+
+  <!-- ===== External backends ===== -->
+  <rect x="120" y="660" width="200" height="60" rx="10" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="220" y="684" text-anchor="middle" class="lbl">R2 bucket</text>
+  <text x="220" y="702" text-anchor="middle" class="mono">askit-fuse-index-cache</text>
+
+  <rect x="360" y="660" width="200" height="60" rx="10" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="460" y="684" text-anchor="middle" class="lbl">archive.tw API</text>
+  <text x="460" y="702" text-anchor="middle" class="txt">SayIt 公開逐字稿</text>
+
+  <!-- ask -> R2 -->
+  <line x1="220" y1="574" x2="220" y2="660" stroke="#059669" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+  <text x="228" y="620" class="edge">讀 index + manifest</text>
+  <!-- cag -> archive -->
+  <line x1="625" y1="474" x2="560" y2="676" stroke="#2563eb" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+  <text x="565" y="560" class="edge" transform="rotate(0)">即時檢索</text>
+
+  <!-- ===== Index build / refresh pipeline ===== -->
+  <rect x="120" y="790" width="940" height="250" rx="12" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="140" y="816" class="secT" fill="#7e22ce">索引建置與自動刷新 · scripts/build-ask-index.ts · .github/workflows/refresh-cag-index.yml</text>
+
+  <!-- triggers -->
+  <rect x="140" y="832" width="250" height="92" rx="8" fill="#fff" stroke="#d8b4fe"/>
+  <text x="156" y="852" class="lbl">觸發 (refresh-cag-index.yml)</text>
+  <text x="156" y="872" class="mono">repository_dispatch: sayit-updated</text>
+  <text x="156" y="890" class="mono">schedule: 30 13 * * * (backstop)</text>
+  <text x="156" y="908" class="mono">workflow_dispatch (手動, 可 deploy)</text>
+
+  <!-- build steps -->
+  <rect x="420" y="832" width="290" height="92" rx="8" fill="#fff" stroke="#d8b4fe"/>
+  <text x="436" y="852" class="lbl">npm run build:index</text>
+  <text x="436" y="872" class="mono">D1 sections (name LIKE '唐鳳%')</text>
+  <text x="436" y="890" class="txt">→ 過濾 ≤100字 / 近 2 年</text>
+  <text x="436" y="908" class="mono">→ Fuse.createIndex → JSON + manifest</text>
+
+  <!-- upload -->
+  <rect x="740" y="832" width="300" height="92" rx="8" fill="#fff" stroke="#d8b4fe"/>
+  <text x="756" y="852" class="lbl">wrangler r2 object put</text>
+  <text x="756" y="872" class="mono">audrey-tang.json</text>
+  <text x="756" y="890" class="mono">audrey-tang.manifest.json (sidecar)</text>
+  <text x="756" y="908" class="txt">+ deploy --dry-run 驗證</text>
+
+  <line x1="390" y1="878" x2="420" y2="878" stroke="#9333ea" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="710" y1="878" x2="740" y2="878" stroke="#9333ea" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- D1 source -->
+  <rect x="420" y="952" width="290" height="44" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="565" y="979" text-anchor="middle" class="mono">D1 · sayit-database (sections)</text>
+  <line x1="565" y1="952" x2="565" y2="924" stroke="#9333ea" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- upload -> R2 (curved up) -->
+  <path d="M 890 832 C 890 760 300 760 220 720" fill="none" stroke="#9333ea" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#arrow)"/>
+  <text x="600" y="752" text-anchor="middle" class="edge">上傳 → R2 (執行期經 manifest fingerprint 熱重載)</text>
+
+  <!-- legend -->
+  <g>
+    <rect x="760" y="100" width="300" height="78" rx="10" fill="#fff" stroke="#cbd5e1"/>
+    <text x="775" y="120" class="lbl">圖例</text>
+    <rect x="775" y="130" width="16" height="12" rx="3" fill="#f0fdf4" stroke="#22c55e"/>
+    <text x="798" y="140" class="txt">/ask · Fuse 既有流程</text>
+    <rect x="775" y="150" width="16" height="12" rx="3" fill="#eff6ff" stroke="#2563eb"/>
+    <text x="798" y="160" class="txt">/cag · Workers AI 新增 (PR #12)</text>
+    <rect x="940" y="130" width="16" height="12" rx="3" fill="#faf5ff" stroke="#a855f7"/>
+    <text x="963" y="140" class="txt">索引刷新管線</text>
+    <rect x="940" y="150" width="16" height="12" rx="3" fill="#fff7ed" stroke="#f59e0b"/>
+    <text x="963" y="160" class="txt">外部資料源</text>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "deploy": "npx wrangler deploy",
     "tail": "npx wrangler tail",
     "typecheck": "tsc --noEmit",
-    "build:index": "tsx --tsconfig scripts/tsconfig.json scripts/build-ask-index.ts"
+    "build:index": "tsx --tsconfig scripts/tsconfig.json scripts/build-ask-index.ts",
+    "build:index:lore": "MAX_SECTION_CHARS=2200 YEARS_BACK=30 npm run build:index"
   },
   "dependencies": {
     "fuse.js": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "deploy": "npx wrangler deploy",
     "tail": "npx wrangler tail",
     "typecheck": "tsc --noEmit",
-    "build:index": "tsx --tsconfig scripts/tsconfig.json scripts/build-ask-index.ts",
-    "build:index:lore": "MAX_SECTION_CHARS=2200 YEARS_BACK=30 npm run build:index"
+    "test": "node --import tsx --test test/*.test.ts",
+    "build:index": "tsx --tsconfig scripts/tsconfig.json scripts/build-ask-index.ts"
   },
   "dependencies": {
     "fuse.js": "^7.3.0",

--- a/scripts/build-ask-index.ts
+++ b/scripts/build-ask-index.ts
@@ -9,12 +9,14 @@
  *   SPEAKER_LIKE  speakers.name 的 LIKE 條件（預設 '唐鳳%'）
  *   R2_BUCKET     R2 bucket 名稱（預設 askit-fuse-index-cache）
  *   R2_KEY        上傳到 R2 的 key（預設 ask-index/audrey-tang.json）
+ *   R2_MANIFEST_KEY  上傳 sidecar manifest 的 key（預設 ask-index/audrey-tang.manifest.json）
  *   MAX_SECTION_CHARS  段落純文字字數上限（預設 100）
  *   YEARS_BACK    只保留最近幾年的內容（預設 2，以 filename 開頭日期判斷）
  *   LOCAL=1       對 D1 下 --local（預設用 --remote 對線上資料庫查詢）
  *   SKIP_UPLOAD=1 只在本地產出 JSON，不上傳 R2
  */
 import { execSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import Fuse from 'fuse.js'
@@ -22,6 +24,8 @@ import {
   ASK_FUSE_OPTIONS,
   ASK_INDEX_R2_KEY,
   ASK_INDEX_VERSION,
+  manifestKeyForIndexKey,
+  type AskIndexManifest,
   type AskIndexPayload,
   type SectionRow,
 } from '../src/utils/askIndexFormat'
@@ -30,6 +34,8 @@ const D1_DATABASE = process.env.D1_DATABASE ?? 'sayit-database'
 const R2_BUCKET = process.env.R2_BUCKET ?? 'askit-fuse-index-cache' // or askit-fuse-index-cache-preview
 const SPEAKER_LIKE = process.env.SPEAKER_LIKE ?? '唐鳳%'
 const R2_KEY = process.env.R2_KEY ?? ASK_INDEX_R2_KEY
+const R2_MANIFEST_KEY =
+  process.env.R2_MANIFEST_KEY ?? manifestKeyForIndexKey(R2_KEY)
 const MAX_SECTION_CHARS = Number(process.env.MAX_SECTION_CHARS ?? '100')
 const YEARS_BACK = Number(process.env.YEARS_BACK ?? '2')
 const SKIP_UPLOAD = process.env.SKIP_UPLOAD === '1'
@@ -139,10 +145,11 @@ async function main() {
 
   const keys = (ASK_FUSE_OPTIONS.keys ?? []) as string[]
   const fuseIndex = Fuse.createIndex<SectionRow>(keys, rows)
+  const generatedAt = new Date().toISOString()
 
   const payload: AskIndexPayload = {
     v: ASK_INDEX_VERSION,
-    generatedAt: new Date().toISOString(),
+    generatedAt,
     speakerLike: SPEAKER_LIKE,
     rowCount: rows.length,
     rows,
@@ -154,8 +161,30 @@ async function main() {
   const outPath = path.join(outDir, path.basename(R2_KEY))
   const json = JSON.stringify(payload)
   await writeFile(outPath, json)
-  const sizeMB = (Buffer.byteLength(json) / 1024 / 1024).toFixed(2)
+  const indexBytes = Buffer.byteLength(json)
+  const indexSha256 = createHash('sha256').update(json).digest('hex')
+  const sizeMB = (indexBytes / 1024 / 1024).toFixed(2)
   console.log(`[build-ask-index] Wrote ${outPath} (${sizeMB} MB)`)
+
+  const manifest: AskIndexManifest = {
+    v: ASK_INDEX_VERSION,
+    generatedAt,
+    indexKey: R2_KEY,
+    indexSha256,
+    indexBytes,
+    speakerLike: SPEAKER_LIKE,
+    rowCount: rows.length,
+    queriedRowCount: queriedRows.length,
+    maxSectionChars: MAX_SECTION_CHARS,
+    yearsBack: YEARS_BACK,
+    cutoffDate,
+    d1Database: D1_DATABASE,
+    local: D1_FLAG === '--local',
+  }
+  const manifestPath = path.join(outDir, path.basename(R2_MANIFEST_KEY))
+  const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`
+  await writeFile(manifestPath, manifestJson)
+  console.log(`[build-ask-index] Wrote ${manifestPath}`)
 
   if (SKIP_UPLOAD) {
     console.log('[build-ask-index] SKIP_UPLOAD=1, not uploading to R2')
@@ -171,6 +200,15 @@ async function main() {
     `--content-type "application/json; charset=utf-8" ` +
     `--remote`
   execSync(upCmd, { stdio: 'inherit' })
+  console.log(
+    `[build-ask-index] Uploading manifest to R2 ${R2_BUCKET}/${R2_MANIFEST_KEY} ...`,
+  )
+  const manifestCmd =
+    `npx wrangler r2 object put ${shellQuote(`${R2_BUCKET}/${R2_MANIFEST_KEY}`)} ` +
+    `--file ${shellQuote(manifestPath)} ` +
+    `--content-type "application/json; charset=utf-8" ` +
+    `--remote`
+  execSync(manifestCmd, { stdio: 'inherit' })
   console.log('[build-ask-index] Done.')
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { renderHomePage } from './pages/home'
 import { renderPrivacyPolicyPage } from './pages/privacy'
 import { renderTermsOfUsePage } from './pages/terms'
-import { DEFAULT_CAG_MODEL, streamCagAnswer } from './utils/cag'
+import { DEFAULT_CAG_MODEL, getCagStatus, streamCagAnswer } from './utils/cag'
 import {
   findClosestMatchingSection,
   findRandomSection,
@@ -17,6 +17,7 @@ type Bindings = {
   LINE_CHANNEL_ACCESS_TOKEN: string
   LINE_CHANNEL_SECRET: string
   ASK_MODEL?: string
+  ASK_ARCHIVE_BASE_URL?: string
   ASK_INDEX: R2Bucket
   AI: {
     run: (model: string, input: Record<string, unknown>) => Promise<unknown>
@@ -134,9 +135,17 @@ app.get('/ask/:question', async (c) => {
   }
 })
 
+app.get('/cag/status', (c) => {
+  return c.json(getCagStatus({
+    archiveBaseUrl: c.env.ASK_ARCHIVE_BASE_URL,
+    model: c.env.ASK_MODEL || DEFAULT_CAG_MODEL,
+  }))
+})
+
 app.get('/cag/:question', async (c) => {
   const question = decodeRouteParam(c.req.param('question'))
-  return streamCagAnswer(c.env.AI, c.env.ASK_INDEX, question, {
+  return streamCagAnswer(c.env.AI, question, {
+    archiveBaseUrl: c.env.ASK_ARCHIVE_BASE_URL,
     model: c.req.query('model') || c.env.ASK_MODEL || DEFAULT_CAG_MODEL,
     topK: parsePositiveInteger(c.req.query('top_k') ?? c.req.query('topK'), 6),
     maxCompletionTokens: parsePositiveInteger(
@@ -173,7 +182,8 @@ app.post('/cag', async (c) => {
     ? payload.model
     : c.env.ASK_MODEL || DEFAULT_CAG_MODEL
 
-  return streamCagAnswer(c.env.AI, c.env.ASK_INDEX, question, {
+  return streamCagAnswer(c.env.AI, question, {
+    archiveBaseUrl: c.env.ASK_ARCHIVE_BASE_URL,
     model,
     topK,
     maxCompletionTokens,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { renderHomePage } from './pages/home'
 import { renderPrivacyPolicyPage } from './pages/privacy'
 import { renderTermsOfUsePage } from './pages/terms'
+import { DEFAULT_CAG_MODEL, streamCagAnswer } from './utils/cag'
 import {
   findClosestMatchingSection,
   findRandomSection,
@@ -15,7 +16,11 @@ import {
 type Bindings = {
   LINE_CHANNEL_ACCESS_TOKEN: string
   LINE_CHANNEL_SECRET: string
+  ASK_MODEL?: string
   ASK_INDEX: R2Bucket
+  AI: {
+    run: (model: string, input: Record<string, unknown>) => Promise<unknown>
+  }
 }
 
 type LineMessageEvent = {
@@ -34,10 +39,25 @@ const LINE_REPLY_ENDPOINT = 'https://api.line.me/v2/bot/message/reply'
 const REPLY_TOKEN_TTL_MS = 50_000
 const ROBOTS_TXT = `User-agent: *
 Disallow: /ask/
+Disallow: /cag/
 Disallow: /webhook
 `
 
 const app = new Hono<{ Bindings: Bindings }>()
+
+function decodeRouteParam(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback
+}
 
 // HMAC-SHA256(channelSecret, rawBody), base64-encoded.
 // LINE 平台會在 x-line-signature 帶上同樣的值，需以等長時間比對防止 timing attack。
@@ -91,13 +111,7 @@ app.get('/robots.txt', (c) => {
 })
 
 app.get('/ask/:question', async (c) => {
-  const raw = c.req.param('question')
-  let question: string
-  try {
-    question = decodeURIComponent(raw)
-  } catch {
-    question = raw
-  }
+  const question = decodeRouteParam(c.req.param('question'))
 
   try {
     const hit = isRandomAskQuestion(question)
@@ -118,6 +132,52 @@ app.get('/ask/:question', async (c) => {
     console.error(e)
     return c.text('查詢發生錯誤', 500)
   }
+})
+
+app.get('/cag/:question', async (c) => {
+  const question = decodeRouteParam(c.req.param('question'))
+  return streamCagAnswer(c.env.AI, c.env.ASK_INDEX, question, {
+    model: c.req.query('model') || c.env.ASK_MODEL || DEFAULT_CAG_MODEL,
+    topK: parsePositiveInteger(c.req.query('top_k') ?? c.req.query('topK'), 6),
+    maxCompletionTokens: parsePositiveInteger(
+      c.req.query('max_tokens') ?? c.req.query('maxTokens'),
+      900,
+    ),
+  })
+})
+
+app.post('/cag', async (c) => {
+  let payload: { question?: unknown; topK?: unknown; top_k?: unknown; model?: unknown; maxTokens?: unknown; max_tokens?: unknown }
+  try {
+    payload = await c.req.json()
+  } catch {
+    return c.text('Invalid JSON payload', 400)
+  }
+
+  const question = typeof payload.question === 'string' ? payload.question : ''
+  if (question.trim() === '') {
+    return c.text('question is required', 400)
+  }
+
+  const topK = typeof payload.topK === 'number'
+    ? payload.topK
+    : typeof payload.top_k === 'number'
+      ? payload.top_k
+      : 6
+  const maxCompletionTokens = typeof payload.maxTokens === 'number'
+    ? payload.maxTokens
+    : typeof payload.max_tokens === 'number'
+      ? payload.max_tokens
+      : 900
+  const model = typeof payload.model === 'string'
+    ? payload.model
+    : c.env.ASK_MODEL || DEFAULT_CAG_MODEL
+
+  return streamCagAnswer(c.env.AI, c.env.ASK_INDEX, question, {
+    model,
+    topK,
+    maxCompletionTokens,
+  })
 })
 
 app.post('/webhook', async (c) => {

--- a/src/utils/askIndexFormat.ts
+++ b/src/utils/askIndexFormat.ts
@@ -2,6 +2,7 @@ import Fuse, { type IFuseOptions } from 'fuse.js'
 
 export const ASK_INDEX_VERSION = 1
 export const ASK_INDEX_R2_KEY = 'ask-index/audrey-tang.json'
+export const ASK_INDEX_MANIFEST_R2_KEY = 'ask-index/audrey-tang.manifest.json'
 
 export type SectionRow = {
   filename: string
@@ -21,6 +22,29 @@ export type AskIndexPayload = {
   rows: SectionRow[]
   /** Fuse.createIndex(...).toJSON() 結果 */
   index: unknown
+}
+
+export type AskIndexManifest = {
+  v: number
+  generatedAt: string
+  indexKey: string
+  indexSha256: string
+  indexBytes: number
+  speakerLike: string
+  rowCount: number
+  queriedRowCount: number
+  maxSectionChars: number
+  yearsBack: number
+  cutoffDate: string
+  d1Database: string
+  local: boolean
+}
+
+export function manifestKeyForIndexKey(indexKey: string): string {
+  if (indexKey === ASK_INDEX_R2_KEY) return ASK_INDEX_MANIFEST_R2_KEY
+  return indexKey.endsWith('.json')
+    ? indexKey.replace(/\.json$/, '.manifest.json')
+    : `${indexKey}.manifest.json`
 }
 
 export const ASK_FUSE_OPTIONS: IFuseOptions<SectionRow> = {

--- a/src/utils/cag.ts
+++ b/src/utils/cag.ts
@@ -276,6 +276,7 @@ export async function streamCagAnswer(
       4_096,
     ),
     temperature: 0.2,
+    chat_template_kwargs: { thinking: false },
   })
 
   const body = aiResultToStream(stream)

--- a/src/utils/cag.ts
+++ b/src/utils/cag.ts
@@ -1,0 +1,293 @@
+import {
+  buildArchiveTwSectionHref,
+  findClosestMatchingSections,
+  htmlToPlainText,
+  type AskSearchResult,
+} from './search'
+
+type WorkersAiBinding = {
+  run: (model: string, input: Record<string, unknown>) => Promise<unknown>
+}
+
+type ChatMessage = {
+  role: 'system' | 'user'
+  content: string
+}
+
+export type CagOptions = {
+  model?: string
+  topK?: number
+  maxCompletionTokens?: number
+}
+
+export const DEFAULT_CAG_MODEL = '@cf/moonshotai/kimi-k2.6'
+const DEFAULT_TOP_K = 6
+const MAX_TOP_K = 12
+const DEFAULT_MAX_COMPLETION_TOKENS = 900
+const MAX_CONTEXT_SECTION_CHARS = 2_200
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.max(min, Math.min(max, Math.floor(value)))
+}
+
+function sourceLabel(hit: AskSearchResult): string {
+  const speaker = hit.name?.trim()
+  return speaker ? `${hit.display_name} — ${speaker}` : hit.display_name
+}
+
+function sourceHref(hit: AskSearchResult): string {
+  return buildArchiveTwSectionHref(
+    hit.filename,
+    hit.section_id,
+    hit.nest_filename,
+  )
+}
+
+function truncateContextText(value: string): string {
+  if (value.length <= MAX_CONTEXT_SECTION_CHARS) return value
+  return `${value.slice(0, MAX_CONTEXT_SECTION_CHARS).trimEnd()}\n[... excerpt trimmed ...]`
+}
+
+function footnoteForHit(hit: AskSearchResult): string {
+  return `[${sourceLabel(hit)}](${sourceHref(hit)})`
+}
+
+function buildCagMessages(question: string, hits: AskSearchResult[]): ChatMessage[] {
+  const lore = hits
+    .map((hit, index) => {
+      const n = index + 1
+      const content = truncateContextText(htmlToPlainText(hit.content))
+      return [
+        `[${n}] ${sourceLabel(hit)}`,
+        `url: ${sourceHref(hit)}`,
+        '```text',
+        content,
+        '```',
+      ].join('\n')
+    })
+    .join('\n\n')
+
+  return [
+    {
+      role: 'system',
+      content: [
+        'You answer questions using only the cited SayIt transcript excerpts supplied by the user.',
+        'Do not invent details outside the excerpts.',
+        'When stating a concrete fact, cite the source number as [1], [2], etc.',
+        'If the excerpts do not support an answer, say so clearly.',
+        'Use Traditional Chinese when the user asks in Chinese or includes #zh-tw.',
+      ].join(' '),
+    },
+    {
+      role: 'user',
+      content: [
+        '<lore>',
+        lore,
+        '</lore>',
+        '',
+        `Question: ${question}`,
+        '',
+        'Answer concisely. Prefer exact wording from the excerpts where useful.',
+      ].join('\n'),
+    },
+  ]
+}
+
+function aiResultToStream(result: unknown): ReadableStream<Uint8Array> {
+  if (result instanceof ReadableStream) {
+    return result as ReadableStream<Uint8Array>
+  }
+  if (result instanceof Response && result.body) {
+    return result.body
+  }
+
+  let text = ''
+  if (typeof result === 'string') {
+    text = result
+  } else if (result && typeof result === 'object') {
+    const obj = result as Record<string, unknown>
+    text =
+      typeof obj.response === 'string'
+        ? obj.response
+        : typeof obj.result === 'string'
+          ? obj.result
+          : JSON.stringify(result)
+  } else {
+    text = String(result ?? '')
+  }
+  return new Response(text).body!
+}
+
+function extractStreamingText(data: string): string {
+  if (data === '[DONE]') return ''
+  try {
+    const parsed = JSON.parse(data) as unknown
+    if (typeof parsed === 'string') return parsed
+    if (!parsed || typeof parsed !== 'object') return ''
+
+    const obj = parsed as Record<string, unknown>
+    if (typeof obj.response === 'string') return obj.response
+    if (typeof obj.output_text === 'string') return obj.output_text
+    if (typeof obj.text === 'string') return obj.text
+    if (typeof obj.result === 'string') return obj.result
+
+    const result = obj.result
+    if (result && typeof result === 'object') {
+      const resultObj = result as Record<string, unknown>
+      if (typeof resultObj.response === 'string') return resultObj.response
+      if (typeof resultObj.text === 'string') return resultObj.text
+    }
+
+    const choices = obj.choices
+    if (Array.isArray(choices) && choices.length > 0) {
+      const choice = choices[0] as Record<string, unknown>
+      if (typeof choice.text === 'string') return choice.text
+      const delta = choice.delta as Record<string, unknown> | undefined
+      if (delta && typeof delta.content === 'string') return delta.content
+      const message = choice.message as Record<string, unknown> | undefined
+      if (message && typeof message.content === 'string') return message.content
+    }
+  } catch {
+    return data
+  }
+  return ''
+}
+
+function workersAiEventStreamToText(): TransformStream<Uint8Array, string> {
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let sawSse = false
+
+  function processLine(line: string, controller: TransformStreamDefaultController<string>) {
+    const trimmed = line.trimEnd()
+    if (trimmed === '') return
+    if (trimmed.startsWith('data:')) {
+      sawSse = true
+      const text = extractStreamingText(trimmed.slice('data:'.length).trim())
+      if (text) controller.enqueue(text)
+      return
+    }
+    if (/^(event|id|retry):/.test(trimmed)) return
+    if (!sawSse) controller.enqueue(`${line}\n`)
+  }
+
+  return new TransformStream<Uint8Array, string>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true })
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
+      for (const line of lines) processLine(line, controller)
+    },
+    flush(controller) {
+      buffer += decoder.decode()
+      if (buffer) {
+        if (sawSse) {
+          processLine(buffer, controller)
+        } else {
+          controller.enqueue(buffer)
+        }
+      }
+    },
+  })
+}
+
+function markdownCitationFootnotes(footnotes: string[]): TransformStream<string, string> {
+  const used = new Set<number>()
+  let state: 'text' | 'citation' = 'text'
+  let digits = ''
+
+  function emitCitation(controller: TransformStreamDefaultController<string>, raw: string) {
+    const index = Number(raw)
+    if (Number.isInteger(index) && index >= 1 && index <= footnotes.length) {
+      used.add(index)
+      controller.enqueue(`[^${index}]`)
+    } else {
+      controller.enqueue(`[${raw}]`)
+    }
+  }
+
+  return new TransformStream<string, string>({
+    transform(chunk, controller) {
+      for (const char of chunk) {
+        if (state === 'text') {
+          if (char === '[') {
+            state = 'citation'
+            digits = ''
+          } else {
+            controller.enqueue(char)
+          }
+          continue
+        }
+
+        if (/\d/.test(char) && digits.length < 9) {
+          digits += char
+          continue
+        }
+        if (char === ']' && digits !== '') {
+          emitCitation(controller, digits)
+          state = 'text'
+          digits = ''
+          continue
+        }
+        controller.enqueue(`[${digits}${char}`)
+        state = 'text'
+        digits = ''
+      }
+    },
+    flush(controller) {
+      if (state === 'citation') {
+        controller.enqueue(`[${digits}`)
+      }
+      const indexes = [...used].sort((a, b) => a - b)
+      if (indexes.length > 0) {
+        controller.enqueue('\n\n')
+        for (const index of indexes) {
+          controller.enqueue(`[^${index}]: ${footnotes[index - 1]}\n`)
+        }
+      }
+    },
+  })
+}
+
+export async function streamCagAnswer(
+  ai: WorkersAiBinding,
+  bucket: R2Bucket,
+  question: string,
+  options?: CagOptions,
+): Promise<Response> {
+  const topK = clampInteger(options?.topK ?? DEFAULT_TOP_K, 1, MAX_TOP_K)
+  const hits = await findClosestMatchingSections(bucket, question, { limit: topK })
+  if (hits.length === 0) {
+    return new Response('找不到符合條件的逐字稿段落', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=UTF-8' },
+    })
+  }
+
+  const model = options?.model || DEFAULT_CAG_MODEL
+  const messages = buildCagMessages(question, hits)
+  const stream = await ai.run(model, {
+    messages,
+    stream: true,
+    max_completion_tokens: clampInteger(
+      options?.maxCompletionTokens ?? DEFAULT_MAX_COMPLETION_TOKENS,
+      1,
+      4_096,
+    ),
+    temperature: 0.2,
+  })
+
+  const body = aiResultToStream(stream)
+    .pipeThrough(workersAiEventStreamToText())
+    .pipeThrough(markdownCitationFootnotes(hits.map(footnoteForHit)))
+    .pipeThrough(new TextEncoderStream())
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=UTF-8',
+      'Cache-Control': 'no-store',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/src/utils/cag.ts
+++ b/src/utils/cag.ts
@@ -1,8 +1,5 @@
 import {
-  buildArchiveTwSectionHref,
-  findClosestMatchingSections,
   htmlToPlainText,
-  type AskSearchResult,
 } from './search'
 
 type WorkersAiBinding = {
@@ -18,30 +15,58 @@ export type CagOptions = {
   model?: string
   topK?: number
   maxCompletionTokens?: number
+  archiveBaseUrl?: string
 }
 
 export const DEFAULT_CAG_MODEL = '@cf/moonshotai/kimi-k2.6'
+export const DEFAULT_ARCHIVE_BASE_URL = 'https://archive.tw'
 const DEFAULT_TOP_K = 6
 const MAX_TOP_K = 12
 const DEFAULT_MAX_COMPLETION_TOKENS = 900
 const MAX_CONTEXT_SECTION_CHARS = 2_200
+const MAX_SEARCH_VARIANTS = 6
+
+type ArchiveSearchResult = {
+  title?: string
+  url?: string
+  date?: string
+  speaker?: string
+  snippet?: string
+}
+
+type ArchiveSearchResponse = {
+  results?: ArchiveSearchResult[]
+}
+
+type ArchiveSectionResponse = {
+  filename?: string
+  nest_filename?: string | null
+  section_id?: number | string
+  section_content?: string | null
+  previous_content?: string | null
+  next_content?: string | null
+  display_name?: string | null
+  name?: string | null
+}
+
+export type CagSource = {
+  content: string
+  href: string
+  label: string
+  sectionId: number | null
+}
+
+export type CagStatus = {
+  retriever: 'archive-search'
+  archiveBaseUrl: string
+  model: string
+  maxTopK: number
+  maxContextSectionChars: number
+}
 
 function clampInteger(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min
   return Math.max(min, Math.min(max, Math.floor(value)))
-}
-
-function sourceLabel(hit: AskSearchResult): string {
-  const speaker = hit.name?.trim()
-  return speaker ? `${hit.display_name} — ${speaker}` : hit.display_name
-}
-
-function sourceHref(hit: AskSearchResult): string {
-  return buildArchiveTwSectionHref(
-    hit.filename,
-    hit.section_id,
-    hit.nest_filename,
-  )
 }
 
 function truncateContextText(value: string): string {
@@ -49,18 +74,18 @@ function truncateContextText(value: string): string {
   return `${value.slice(0, MAX_CONTEXT_SECTION_CHARS).trimEnd()}\n[... excerpt trimmed ...]`
 }
 
-function footnoteForHit(hit: AskSearchResult): string {
-  return `[${sourceLabel(hit)}](${sourceHref(hit)})`
+function footnoteForSource(source: CagSource): string {
+  return `[${source.label}](${source.href})`
 }
 
-function buildCagMessages(question: string, hits: AskSearchResult[]): ChatMessage[] {
-  const lore = hits
-    .map((hit, index) => {
+function buildCagMessages(question: string, sources: CagSource[]): ChatMessage[] {
+  const lore = sources
+    .map((source, index) => {
       const n = index + 1
-      const content = truncateContextText(htmlToPlainText(hit.content))
+      const content = truncateContextText(htmlToPlainText(source.content))
       return [
-        `[${n}] ${sourceLabel(hit)}`,
-        `url: ${sourceHref(hit)}`,
+        `[${n}] ${source.label}`,
+        `url: ${source.href}`,
         '```text',
         content,
         '```',
@@ -76,6 +101,7 @@ function buildCagMessages(question: string, hits: AskSearchResult[]): ChatMessag
         'Do not invent details outside the excerpts.',
         'When stating a concrete fact, cite the source number as [1], [2], etc.',
         'If the excerpts do not support an answer, say so clearly.',
+        'Cite the section that directly supports each claim.',
         'Use Traditional Chinese when the user asks in Chinese or includes #zh-tw.',
       ].join(' '),
     },
@@ -92,6 +118,184 @@ function buildCagMessages(question: string, hits: AskSearchResult[]): ChatMessag
       ].join('\n'),
     },
   ]
+}
+
+function normalizeArchiveBaseUrl(value: string | undefined): string {
+  const raw = (value || DEFAULT_ARCHIVE_BASE_URL).trim()
+  try {
+    const url = new URL(raw)
+    url.pathname = url.pathname.replace(/\/+$/, '')
+    url.search = ''
+    url.hash = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return DEFAULT_ARCHIVE_BASE_URL
+  }
+}
+
+function stripQuestionDirectives(question: string): string {
+  return question
+    .replace(/#[\p{Letter}\p{Number}_-]+/gu, ' ')
+    .replace(/^\s*(?:請|麻煩)?\s*用\s+[\s\S]{0,40}?回答[:：]\s*/u, '')
+    .replace(/^\s*(?:請|麻煩)?\s*(?:回答|說明|解釋|summarize|answer)\s*[:：]?\s*/iu, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function pushUnique(values: string[], value: string) {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized && !values.includes(normalized)) values.push(normalized)
+}
+
+export function buildCagQueryVariants(question: string): string[] {
+  const cleaned = stripQuestionDirectives(question)
+    .replace(/[?？!！。.,，;；:：()[\]{}「」『』"“”'‘’]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const variants: string[] = []
+  pushUnique(variants, cleaned)
+
+  const withoutQuestionWords = cleaned
+    .replace(/(如何|怎麼|怎么|為何|爲何|什麼|什么|請問|請|回答|說明|解釋)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  pushUnique(variants, withoutQuestionWords)
+
+  const hanRuns = [...withoutQuestionWords.matchAll(/\p{Script=Han}{2,}/gu)]
+    .map((match) => match[0])
+  for (const run of hanRuns) {
+    if (run.length <= 2) {
+      pushUnique(variants, run)
+      continue
+    }
+    pushUnique(variants, run)
+    for (let i = 0; i < run.length - 1; i += 2) {
+      pushUnique(variants, run.slice(i, i + 2))
+    }
+    for (let i = 1; i < run.length - 1; i += 2) {
+      pushUnique(variants, run.slice(i, i + 2))
+    }
+  }
+
+  const latinTokens = withoutQuestionWords.match(/[A-Za-z0-9][A-Za-z0-9._-]{1,}/g) ?? []
+  for (const token of latinTokens) pushUnique(variants, token)
+
+  return variants.slice(0, MAX_SEARCH_VARIANTS)
+}
+
+export function parseArchiveSectionId(href: string): number | null {
+  const match = href.match(/#s(\d+)\b/)
+  if (!match) return null
+  const value = Number(match[1])
+  return Number.isInteger(value) ? value : null
+}
+
+function absoluteArchiveHref(baseUrl: string, href: string | undefined): string | null {
+  if (!href) return null
+  try {
+    return new URL(href, baseUrl).toString()
+  } catch {
+    return null
+  }
+}
+
+async function fetchArchiveJson<T>(url: URL): Promise<T | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) return null
+    return (await response.json()) as T
+  } catch (e) {
+    console.error('archive fetch failed:', e)
+    return null
+  }
+}
+
+async function searchArchive(
+  baseUrl: string,
+  query: string,
+  limit: number,
+): Promise<ArchiveSearchResult[]> {
+  const url = new URL('/api/search.json', baseUrl)
+  url.searchParams.set('q', query)
+  url.searchParams.set('limit', String(limit))
+  const payload = await fetchArchiveJson<ArchiveSearchResponse>(url)
+  return Array.isArray(payload?.results) ? payload.results : []
+}
+
+async function hydrateArchiveSection(
+  baseUrl: string,
+  hit: ArchiveSearchResult,
+): Promise<CagSource | null> {
+  const href = absoluteArchiveHref(baseUrl, hit.url)
+  if (!href) return null
+
+  const sectionId = parseArchiveSectionId(href)
+  if (!sectionId) {
+    const snippet = hit.snippet?.trim()
+    if (!snippet) return null
+    const label = [hit.title, hit.speaker].filter(Boolean).join(' — ') || href
+    return { content: snippet, href, label, sectionId: null }
+  }
+
+  const url = new URL(`/api/section/${sectionId}`, baseUrl)
+  const section = await fetchArchiveJson<ArchiveSectionResponse>(url)
+  const parts = [
+    section?.previous_content,
+    section?.section_content,
+    section?.next_content,
+  ]
+    .map((value) => htmlToPlainText(value ?? ''))
+    .filter(Boolean)
+  const content = parts.length > 0 ? parts.join('\n\n') : (hit.snippet ?? '')
+  if (content.trim() === '') return null
+
+  const displayName = section?.display_name?.trim() || hit.title?.trim() || href
+  const speaker = section?.name?.trim() || hit.speaker?.trim()
+  const label = speaker ? `${displayName} — ${speaker}` : displayName
+  return { content, href, label, sectionId }
+}
+
+export async function retrieveCagSources(
+  question: string,
+  options?: { topK?: number; archiveBaseUrl?: string },
+): Promise<CagSource[]> {
+  const topK = clampInteger(options?.topK ?? DEFAULT_TOP_K, 1, MAX_TOP_K)
+  const baseUrl = normalizeArchiveBaseUrl(options?.archiveBaseUrl)
+  const variants = buildCagQueryVariants(question)
+  const perQueryLimit = Math.max(topK * 2, 8)
+
+  const searchResults = await Promise.all(
+    variants.map((variant) => searchArchive(baseUrl, variant, perQueryLimit)),
+  )
+  const seen = new Set<string>()
+  const hits: ArchiveSearchResult[] = []
+  for (const result of searchResults.flat()) {
+    const href = absoluteArchiveHref(baseUrl, result.url)
+    if (!href || seen.has(href)) continue
+    seen.add(href)
+    hits.push(result)
+  }
+
+  const hydrated = await Promise.all(
+    hits.slice(0, Math.max(topK * 3, 12)).map((hit) => hydrateArchiveSection(baseUrl, hit)),
+  )
+  return hydrated.filter((source): source is CagSource => source !== null).slice(0, topK)
+}
+
+export function getCagStatus(options?: {
+  archiveBaseUrl?: string
+  model?: string
+}): CagStatus {
+  return {
+    retriever: 'archive-search',
+    archiveBaseUrl: normalizeArchiveBaseUrl(options?.archiveBaseUrl),
+    model: options?.model || DEFAULT_CAG_MODEL,
+    maxTopK: MAX_TOP_K,
+    maxContextSectionChars: MAX_CONTEXT_SECTION_CHARS,
+  }
 }
 
 function aiResultToStream(result: unknown): ReadableStream<Uint8Array> {
@@ -192,7 +396,7 @@ function workersAiEventStreamToText(): TransformStream<Uint8Array, string> {
   })
 }
 
-function markdownCitationFootnotes(footnotes: string[]): TransformStream<string, string> {
+export function markdownCitationFootnotes(footnotes: string[]): TransformStream<string, string> {
   const used = new Set<number>()
   let state: 'text' | 'citation' = 'text'
   let digits = ''
@@ -252,13 +456,15 @@ function markdownCitationFootnotes(footnotes: string[]): TransformStream<string,
 
 export async function streamCagAnswer(
   ai: WorkersAiBinding,
-  bucket: R2Bucket,
   question: string,
   options?: CagOptions,
 ): Promise<Response> {
   const topK = clampInteger(options?.topK ?? DEFAULT_TOP_K, 1, MAX_TOP_K)
-  const hits = await findClosestMatchingSections(bucket, question, { limit: topK })
-  if (hits.length === 0) {
+  const sources = await retrieveCagSources(question, {
+    topK,
+    archiveBaseUrl: options?.archiveBaseUrl,
+  })
+  if (sources.length === 0) {
     return new Response('找不到符合條件的逐字稿段落', {
       status: 404,
       headers: { 'Content-Type': 'text/plain; charset=UTF-8' },
@@ -266,7 +472,7 @@ export async function streamCagAnswer(
   }
 
   const model = options?.model || DEFAULT_CAG_MODEL
-  const messages = buildCagMessages(question, hits)
+  const messages = buildCagMessages(question, sources)
   const stream = await ai.run(model, {
     messages,
     stream: true,
@@ -281,7 +487,7 @@ export async function streamCagAnswer(
 
   const body = aiResultToStream(stream)
     .pipeThrough(workersAiEventStreamToText())
-    .pipeThrough(markdownCitationFootnotes(hits.map(footnoteForHit)))
+    .pipeThrough(markdownCitationFootnotes(sources.map(footnoteForSource)))
     .pipeThrough(new TextEncoderStream())
 
   return new Response(body, {

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,6 +1,8 @@
 import type Fuse from 'fuse.js'
 import {
   ASK_INDEX_R2_KEY,
+  manifestKeyForIndexKey,
+  type AskIndexManifest,
   type AskIndexPayload,
   type SectionRow,
   createAskFuseFromPayload,
@@ -34,20 +36,53 @@ type LoadedIndex = {
   rows: SectionRow[]
   rowCount: number
   generatedAt: string
+  indexKey: string
+  indexSha256: string | null
 }
 
 const LINE_FLEX_BODY_MAX_CHARS = 280
 const LINE_FLEX_ALT_TEXT_MAX_CHARS = 1_500
+const INDEX_MANIFEST_CHECK_MS = 60_000
 
 /**
  * Module-level cache：同個 Worker isolate 在多次請求間共用解析後的 Fuse index。
- * 鍵為 R2 key，因此換不同講者索引時可以共存。
+ * 鍵為邏輯 R2 key；小 manifest 會定期檢查，變更時重新載入大 index。
  */
-const indexCache = new Map<string, Promise<LoadedIndex>>()
+type IndexCacheEntry = {
+  checkedAt: number
+  fingerprint: string
+  promise: Promise<LoadedIndex>
+}
+
+const indexCache = new Map<string, IndexCacheEntry>()
+
+function fingerprintForIndex(
+  indexKey: string,
+  manifest: AskIndexManifest | null,
+): string {
+  if (!manifest) return `static:${indexKey}`
+  return [
+    'manifest',
+    manifest.indexKey,
+    manifest.indexSha256,
+    manifest.generatedAt,
+    manifest.rowCount,
+  ].join(':')
+}
+
+async function loadManifestFromR2(
+  bucket: R2Bucket,
+  key: string,
+): Promise<AskIndexManifest | null> {
+  const obj = await bucket.get(key)
+  if (!obj) return null
+  return JSON.parse(await obj.text()) as AskIndexManifest
+}
 
 async function loadIndexFromR2(
   bucket: R2Bucket,
   key: string,
+  manifest: AskIndexManifest | null,
 ): Promise<LoadedIndex> {
   const obj = await bucket.get(key)
   if (!obj) {
@@ -61,18 +96,48 @@ async function loadIndexFromR2(
     rows: payload.rows,
     rowCount: payload.rowCount,
     generatedAt: payload.generatedAt,
+    indexKey: key,
+    indexSha256: manifest?.indexSha256 ?? null,
   }
 }
 
 async function getIndex(bucket: R2Bucket, key: string): Promise<LoadedIndex> {
   const cached = indexCache.get(key)
-  if (cached) return cached
+  const now = Date.now()
+  if (cached && now - cached.checkedAt < INDEX_MANIFEST_CHECK_MS) {
+    return cached.promise
+  }
 
-  const promise = loadIndexFromR2(bucket, key).catch((e) => {
+  let manifest: AskIndexManifest | null = null
+  try {
+    manifest = await loadManifestFromR2(bucket, manifestKeyForIndexKey(key))
+  } catch (e) {
+    console.error('載入索引 manifest 失敗:', e)
+    if (cached) {
+      cached.checkedAt = now
+      return cached.promise
+    }
+  }
+
+  const indexKey = manifest?.indexKey ?? key
+  const fingerprint = fingerprintForIndex(indexKey, manifest)
+  if (cached && cached.fingerprint === fingerprint) {
+    cached.checkedAt = now
+    return cached.promise
+  }
+
+  const previous = cached
+  const promise = loadIndexFromR2(bucket, indexKey, manifest).catch((e) => {
+    if (previous) {
+      console.error('重新載入索引失敗，沿用既有 cache:', e)
+      previous.checkedAt = now
+      indexCache.set(key, previous)
+      return previous.promise
+    }
     indexCache.delete(key)
     throw e
   })
-  indexCache.set(key, promise)
+  indexCache.set(key, { checkedAt: now, fingerprint, promise })
   return promise
 }
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -13,6 +13,7 @@ export type AskSearchResult = {
   section_id: number
   display_name: string
   section_speaker: string | null
+  name: string | null
 }
 
 type LineTextMessage = {
@@ -83,6 +84,7 @@ function rowToResult(row: SectionRow): AskSearchResult {
     section_id: Number(row.section_id),
     display_name: row.display_name ?? row.filename,
     section_speaker: row.section_speaker,
+    name: row.name,
   }
 }
 
@@ -121,6 +123,36 @@ export async function findClosestMatchingSection(
   const top = hits[0]
   if (!top) return null
   return rowToResult(top.item)
+}
+
+export async function findClosestMatchingSections(
+  bucket: R2Bucket,
+  question: string,
+  options?: {
+    r2Key?: string
+    limit?: number
+  },
+): Promise<AskSearchResult[]> {
+  const key = options?.r2Key ?? ASK_INDEX_R2_KEY
+  const limit = Math.max(1, Math.min(16, Math.floor(options?.limit ?? 6)))
+  const q = normalizeAskSearchQuestion(question)
+  if (q === '') return []
+
+  const { fuse, rowCount } = await getIndex(bucket, key)
+  if (rowCount === 0) return []
+
+  const hits = fuse.search(q, { limit: limit * 3 })
+  const seen = new Set<string>()
+  const results: AskSearchResult[] = []
+  for (const hit of hits) {
+    const result = rowToResult(hit.item)
+    const key = `${result.filename}/${result.nest_filename ?? ''}#${result.section_id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    results.push(result)
+    if (results.length >= limit) break
+  }
+  return results
 }
 
 export async function findRandomSection(

--- a/test/cag.test.ts
+++ b/test/cag.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildCagQueryVariants,
+  markdownCitationFootnotes,
+  parseArchiveSectionId,
+  retrieveCagSources,
+} from '../src/utils/cag'
+
+async function streamToString(stream: ReadableStream<string>): Promise<string> {
+  const reader = stream.getReader()
+  let text = ''
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) return text
+    text += value
+  }
+}
+
+test('buildCagQueryVariants keeps useful Chinese retrieval terms', () => {
+  const variants = buildCagQueryVariants('用 #zh-tw 回答：地神香火如何')
+  assert.equal(variants[0], '地神香火如何')
+  assert.ok(variants.includes('地神'))
+  assert.ok(variants.includes('香火'))
+})
+
+test('parseArchiveSectionId extracts archive anchors', () => {
+  assert.equal(parseArchiveSectionId('https://archive.tw/a/b#s619731'), 619731)
+  assert.equal(parseArchiveSectionId('/demo#s42'), 42)
+  assert.equal(parseArchiveSectionId('/demo'), null)
+})
+
+test('markdownCitationFootnotes rewrites numbered citations and appends used notes', async () => {
+  const input = new ReadableStream<string>({
+    start(controller) {
+      controller.enqueue('A [1] B [99] C [2]')
+      controller.close()
+    },
+  })
+  const output = await streamToString(
+    input.pipeThrough(markdownCitationFootnotes([
+      '[One](https://archive.tw/one#s1)',
+      '[Two](https://archive.tw/two#s2)',
+    ])),
+  )
+  assert.equal(
+    output,
+    'A [^1] B [99] C [^2]\n\n[^1]: [One](https://archive.tw/one#s1)\n[^2]: [Two](https://archive.tw/two#s2)\n',
+  )
+})
+
+test('retrieveCagSources searches archive and hydrates sections with neighbors', async () => {
+  const originalFetch = globalThis.fetch
+  const requests: string[] = []
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = new URL(String(input))
+    requests.push(url.toString())
+    if (url.pathname === '/api/search.json') {
+      return Response.json({
+        results: [
+          {
+            title: 'Demo Speech',
+            url: '/demo#s123',
+            speaker: '唐鳳',
+            snippet: '地神',
+          },
+        ],
+      })
+    }
+    if (url.pathname === '/api/section/123') {
+      return Response.json({
+        section_id: 123,
+        section_content: '<p>中段</p>',
+        previous_content: '<p>前段</p>',
+        next_content: '<p>後段</p>',
+        display_name: 'Demo Speech',
+        name: '唐鳳',
+      })
+    }
+    return new Response('not found', { status: 404 })
+  }
+
+  try {
+    const sources = await retrieveCagSources('地神香火如何', {
+      archiveBaseUrl: 'https://archive.tw',
+      topK: 2,
+    })
+    assert.equal(sources.length, 1)
+    assert.equal(sources[0].href, 'https://archive.tw/demo#s123')
+    assert.equal(sources[0].label, 'Demo Speech — 唐鳳')
+    assert.match(sources[0].content, /前段/)
+    assert.match(sources[0].content, /中段/)
+    assert.match(sources[0].content, /後段/)
+    assert.ok(requests.some((url) => url.includes('/api/search.json?q=%E5%9C%B0%E7%A5%9E')))
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,7 @@
   "vars": {
     // 可在此放置非機敏的環境變數
     // Place non-sensitive environment variables here
-    // "EXAMPLE_VAR": "value"
+    "ASK_MODEL": "@cf/moonshotai/kimi-k2.6"
   },
 
   // R2：載入預先建好的 Fuse.js 索引（由 `npm run build:index` 產出並上傳）。
@@ -27,6 +27,12 @@
       "preview_bucket_name": "askit-fuse-index-cache-preview"
     }
   ],
+
+  // Workers AI：/cag/:question 使用此 binding 呼叫 Kimi K2.6。
+  // Workers AI: /cag/:question uses this binding to call Kimi K2.6.
+  "ai": {
+    "binding": "AI"
+  },
 
   "assets": {
     "directory": "./public"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,8 @@
   "vars": {
     // 可在此放置非機敏的環境變數
     // Place non-sensitive environment variables here
-    "ASK_MODEL": "@cf/moonshotai/kimi-k2.6"
+    "ASK_MODEL": "@cf/moonshotai/kimi-k2.6",
+    "ASK_ARCHIVE_BASE_URL": "https://archive.tw"
   },
 
   // R2：載入預先建好的 Fuse.js 索引（由 `npm run build:index` 產出並上傳）。

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,14 +24,16 @@
     {
       "binding": "ASK_INDEX",
       "bucket_name": "askit-fuse-index-cache",
-      "preview_bucket_name": "askit-fuse-index-cache-preview"
+      "preview_bucket_name": "askit-fuse-index-cache-preview",
+      "remote": true
     }
   ],
 
   // Workers AI：/cag/:question 使用此 binding 呼叫 Kimi K2.6。
   // Workers AI: /cag/:question uses this binding to call Kimi K2.6.
   "ai": {
-    "binding": "AI"
+    "binding": "AI",
+    "remote": true
   },
 
   "assets": {


### PR DESCRIPTION
## Summary
- add Cloudflare Workers AI CAG endpoints that retrieve from the R2 Fuse index and stream Markdown with archive.tw footnotes
- disable Kimi K2.6 template thinking for faster visible streaming on the CAG route
- add a long-lore index build profile plus a repository_dispatch workflow for transcript/sayit-hono-driven refreshes
- document the upstream dispatch step, local remote-binding testing, and preview R2 seeding

## Validation

- [x] npm run typecheck
- [x] npx wrangler deploy --dry-run --outdir /tmp/askit-hono-dry-run
- [x] SKIP_UPLOAD=1 npm run build:index (1.17 MB JSON)
- [x] npx wrangler r2 object put askit-fuse-index-cache-preview/ask-index/audrey-tang.json --file build/audrey-tang.json --content-type 'application/json; charset=utf-8' --remote
- [x] npm run dev -- --port 8788
- [x] curl /ask/random against local dev
- [x] curl -N /cag/AI?top_k=2\&max_tokens=160 against local dev
- [x] npx wrangler deploy   (實測)