### PR TITLE
對超量或異常的請求建立D1追蹤log與自動黑名單（issue #27）

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@
 - 壽命以 R2 物件上傳時間判斷，過期視為未命中並順手刪除。
 - 快取放在獨立的 `ASK_CACHE`（`askit-answer-cache`）bucket；未綁定或讀寫出錯時一律優雅降級（當作未命中、照常生成），不會阻斷回答。實作見 `src/utils/cache.ts`。
 
+### 異常請求追蹤 log 與黑名單
+
+對「超量或異常的請求」建立 D1 追蹤 log，並對累犯自動建立黑名單（issue #27）。資料放在獨立的 `askit-abuse-log` D1 資料庫（binding `ABUSE_DB`），兩張表（schema 見 `db/abuse-log-schema.sql`）：
+
+- **`abuse_log`**：「單一 IP/Id 超量」（觸發限流，全域配額用罄不算）或「問題字串過長」發生時自動寫入一筆：問題（截斷至 200 碼點）、IP（網頁/API 若有）、LINE userId／groupId（若有）、時間戳記，以及與限流同一套的正規化身分 key（`ip:…`／`ip6:…/64`／`line:…`）。
+- **`blacklist`**：同一 key 在計數視窗內累積達門檻次數時，與寫 log 同一筆 D1 batch 交易自動寫入。預設「24 小時內 3 次」，可用 vars 調整（`ABUSE_BLACKLIST_THRESHOLD`、`ABUSE_COUNT_WINDOW_HOURS`；視窗設 `0` = 全期間累計）。
+
+收到請求時，**在任何 DO/KV 限流記帳之前**先比對黑名單：黑名單成員直接擋下（HTTP 回 `403`；LINE 來源僅 ack 不回覆，避免平台重送），完全不消耗全域生成額度，以保障善意使用者。未綁 `ABUSE_DB` 時優雅降級：不寫 log、黑名單視為空。實作見 `src/utils/abuse.ts`。
+
+維運指令：
+
+```bash
+npm run abuse:db:init:local       # 本機 dev 用的 D1 建表（本機 dev 寫本機 D1，不污染正式環境）
+npm run abuse:report              # 近端分析 log → build/abuse-report.html 視覺化報告（遠端資料）
+LOCAL=1 npm run abuse:report      # 同上，改讀本機 D1
+npm run abuse:unban -- <key>      # 解除封鎖（同時清掉該 key 的 log 舊紀錄，否則再犯一次就回到黑名單）
+```
+
+報告內容：事件總數／近 24 小時數、每日趨勢（依異常類型堆疊）、類型與路徑分佈、最常觸發來源 Top 20（標示黑名單）、黑名單清單與最近事件明細。
+
 ### LINE webhook 的 CAG 三段式回覆
 
 CAG 需先檢索 `archive.tw` 再讓 Workers AI 生成，通常要數秒到十幾秒，超過 LINE 對 webhook「**2 秒內必須回 2xx**」的限制；而 LINE Reply API 不支援串流、reply token 為一次性。因此 `/webhook` 採三段式非同步回覆：
@@ -75,9 +95,14 @@ Worker 端 `src/utils/search.ts` 第一次請求時從 R2 抓索引、用 `Fuse.
 │   └── utils/
 │       ├── search.ts              # R2 載入索引 + Fuse 搜尋 + HTML 輸出
 │       ├── cache.ts               # 相同問題的 R2 答案快取（7 天，issue #25）
+│       ├── abuse.ts               # 異常請求追蹤 log 與黑名單（issue #27）
 │       └── askIndexFormat.ts      # build / runtime 共用的型別與 Fuse 設定
+├── db/
+│   └── abuse-log-schema.sql       # abuse_log + blacklist 兩張表的 D1 schema
 ├── scripts/
 │   ├── build-ask-index.ts         # 從 D1 撈段落 → 建 Fuse 索引 → 上傳 R2
+│   ├── abuse-report.ts            # 分析異常請求 log → HTML 視覺化報告
+│   ├── abuse-unban.ts             # 把指定 key 從黑名單移除
 │   └── tsconfig.json
 ├── wrangler.jsonc                 # Workers 設定（R2 binding ASK_INDEX）
 ├── tsconfig.json

--- a/db/abuse-log-schema.sql
+++ b/db/abuse-log-schema.sql
@@ -1,0 +1,38 @@
+-- Issue #27 — 超量／異常請求追蹤 log 與黑名單（兩張表）。
+--
+-- 套用方式（資料庫已由 npm run abuse:db:create 建立）：
+--   npm run abuse:db:init          # 遠端（production）
+--   npm run abuse:db:init:local    # 本機 wrangler dev 用
+--
+-- 冪等：全部使用 IF NOT EXISTS，重跑安全、絕不 DROP。
+
+-- 表 1：每次「單一 IP/Id 超量」（rate_limit）或「問題字串過長」（question_too_long）
+-- 自動寫入一筆。全域配額用罄不算異常、不會寫入。
+CREATE TABLE IF NOT EXISTS abuse_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  key TEXT NOT NULL,           -- 正規化身分 key（與限流 key 同一套）：
+                               --   ip:<IPv4>、ip6:<IPv6 /64>、line:<userId>、
+                               --   line:group:<groupId>、line:room:<roomId>
+  kind TEXT NOT NULL,          -- 'rate_limit' | 'question_too_long'
+  path TEXT NOT NULL,          -- 'ask' | 'cag' | 'webhook'
+  question TEXT NOT NULL,      -- 問題內容（截斷至 200 碼點，避免超長字串塞爆 D1）
+  ip TEXT,                     -- 來源 IP（網頁/API 若有；LINE 事件拿不到使用者 IP）
+  line_id TEXT,                -- LINE userId 或 groupId/roomId（若有）
+  created_at INTEGER NOT NULL  -- 時間戳記（epoch 毫秒，UTC）
+);
+-- 供「同一 key 於視窗內出現幾次」的門檻計數查詢。
+CREATE INDEX IF NOT EXISTS idx_abuse_log_key_created_at ON abuse_log (key, created_at);
+-- 供報表依時間掃描。
+CREATE INDEX IF NOT EXISTS idx_abuse_log_created_at ON abuse_log (created_at);
+
+-- 表 2：黑名單。同一 key 在計數視窗（預設 24 小時）內累積達門檻（預設 3）次
+-- 異常時自動寫入。在黑名單內的請求會在「任何 DO/KV 限流記帳之前」直接擋下，
+-- 不消耗全域生成額度，以保障善意使用者。
+-- 解除封鎖：npm run abuse:unban -- <key>（會同時清掉 abuse_log 的舊紀錄，
+-- 否則計數仍達門檻，下次再犯立即回到黑名單）。
+CREATE TABLE IF NOT EXISTS blacklist (
+  key TEXT PRIMARY KEY,            -- 同 abuse_log.key
+  reason TEXT NOT NULL,            -- 觸發封鎖的最後一種異常 kind
+  offense_count INTEGER NOT NULL,  -- 寫入當下視窗內的累計異常次數
+  created_at INTEGER NOT NULL      -- 寫入時間（epoch 毫秒，UTC）
+);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
     "r2:lifecycle:cache:preview": "wrangler r2 bucket lifecycle set askit-answer-cache-preview --file config/r2-answer-cache-lifecycle.json --force",
     "r2:lifecycle": "npm run r2:lifecycle:cache && npm run r2:lifecycle:cache:preview",
     "vectorize:create": "wrangler vectorize create askit-audrey-tang --dimensions=768 --metric=cosine",
-    "vectorize:sync": "tsx --tsconfig scripts/tsconfig.json scripts/vectorize-sync.ts"
+    "vectorize:sync": "tsx --tsconfig scripts/tsconfig.json scripts/vectorize-sync.ts",
+    "abuse:db:create": "wrangler d1 create askit-abuse-log",
+    "abuse:db:init": "wrangler d1 execute askit-abuse-log --remote --file db/abuse-log-schema.sql --yes",
+    "abuse:db:init:local": "wrangler d1 execute askit-abuse-log --local --file db/abuse-log-schema.sql --yes",
+    "abuse:report": "tsx --tsconfig scripts/tsconfig.json scripts/abuse-report.ts",
+    "abuse:unban": "tsx --tsconfig scripts/tsconfig.json scripts/abuse-unban.ts"
   },
   "dependencies": {
     "fuse.js": "^7.3.0",

--- a/scripts/abuse-report.ts
+++ b/scripts/abuse-report.ts
@@ -1,0 +1,405 @@
+/**
+ * Issue #27 — 近端分析異常請求 log，產出 HTML 視覺化報告。
+ *
+ * 從 D1（abuse_log + blacklist）撈資料，於本機聚合後輸出單檔 HTML
+ * （純 inline CSS 長條圖與表格，無任何外部依賴），預設寫到
+ * build/abuse-report.html。
+ *
+ * 用法（從 repo 根目錄）：
+ *   npm run abuse:report             # 遠端（production）資料
+ *   LOCAL=1 npm run abuse:report     # 本機 wrangler dev 的 D1
+ *
+ * 選填環境變數：
+ *   ABUSE_D1_DATABASE        D1 資料庫名（預設 askit-abuse-log）
+ *   REPORT_DAYS              每日趨勢圖回看天數（預設 14）
+ *   REPORT_MAX_ROWS          最多撈取最近幾筆 log（預設 5000，避免一次撈爆）
+ *   REPORT_TZ_OFFSET_HOURS   報表顯示時區位移（預設 8 = 台北時間）
+ *   REPORT_OUT               輸出路徑（預設 build/abuse-report.html）
+ */
+import { execSync } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const D1_DATABASE = process.env.ABUSE_D1_DATABASE ?? 'askit-abuse-log'
+const D1_FLAG = process.env.LOCAL === '1' ? '--local' : '--remote'
+const REPORT_DAYS = Math.max(1, Number(process.env.REPORT_DAYS ?? '14'))
+const REPORT_MAX_ROWS = Math.max(1, Number(process.env.REPORT_MAX_ROWS ?? '5000'))
+const TZ_OFFSET_HOURS = Number(process.env.REPORT_TZ_OFFSET_HOURS ?? '8')
+const OUT_PATH = process.env.REPORT_OUT ?? path.join('build', 'abuse-report.html')
+
+const RECENT_TABLE_LIMIT = 100
+const TOP_OFFENDERS_LIMIT = 20
+
+// ── D1 CLI（沿用 vectorize-sync 的 execSync + --json envelope 解析）────────────
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+type D1Envelope = {
+  success?: boolean
+  results?: Record<string, unknown>[]
+  error?: string
+}
+
+function parseD1Json(out: string): D1Envelope {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(out)
+  } catch {
+    // 容錯：wrangler 偶爾在 JSON 前後夾雜輸出，截取第一個 JSON 區塊。
+    const start = out.search(/[[{]/)
+    const end = Math.max(out.lastIndexOf(']'), out.lastIndexOf('}'))
+    if (start === -1 || end === -1 || end < start) {
+      throw new Error(`無法解析 wrangler d1 --json 輸出：${out.slice(0, 500)}`)
+    }
+    parsed = JSON.parse(out.slice(start, end + 1))
+  }
+  const envelope = Array.isArray(parsed) ? (parsed[0] as D1Envelope) : (parsed as D1Envelope)
+  if (!envelope || envelope.success === false) {
+    throw new Error(`D1 查詢失敗：${envelope?.error ?? 'unknown error'}`)
+  }
+  return envelope
+}
+
+function d1Query(sql: string): Record<string, unknown>[] {
+  const cmd =
+    `npx wrangler d1 execute ${shellQuote(D1_DATABASE)} ${D1_FLAG} ` +
+    `--json --command ${shellQuote(sql)}`
+  const out = execSync(cmd, { encoding: 'utf-8', maxBuffer: 1024 * 1024 * 256 })
+  return parseD1Json(out).results ?? []
+}
+
+// ── 資料模型 ─────────────────────────────────────────────────────────────────
+type LogRow = {
+  key: string
+  kind: string
+  path: string
+  question: string
+  ip: string | null
+  line_id: string | null
+  created_at: number
+}
+
+type BlacklistRow = {
+  key: string
+  reason: string
+  offense_count: number
+  created_at: number
+}
+
+// ── 時間與輸出小工具 ─────────────────────────────────────────────────────────
+const TZ_MS = TZ_OFFSET_HOURS * 3_600_000
+
+function toLocalDate(ms: number): string {
+  return new Date(ms + TZ_MS).toISOString().slice(0, 10)
+}
+
+function toLocalDateTime(ms: number): string {
+  const iso = new Date(ms + TZ_MS).toISOString()
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)}`
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function clipText(s: string, max: number): string {
+  const chars = [...s]
+  return chars.length <= max ? s : `${chars.slice(0, max).join('')}…`
+}
+
+const KIND_LABELS: Record<string, string> = {
+  rate_limit: '超量（限流觸發）',
+  question_too_long: '問題字串過長',
+}
+
+const KIND_COLORS: Record<string, string> = {
+  rate_limit: '#e4572e',
+  question_too_long: '#2e86ab',
+}
+
+function kindLabel(kind: string): string {
+  return KIND_LABELS[kind] ?? kind
+}
+
+function kindColor(kind: string): string {
+  return KIND_COLORS[kind] ?? '#888'
+}
+
+// ── 報告 HTML ────────────────────────────────────────────────────────────────
+function renderStackedBar(
+  byKind: Map<string, number>,
+  total: number,
+  maxTotal: number,
+): string {
+  if (total === 0 || maxTotal === 0) return '<div class="bar"></div>'
+  const widthPct = (total / maxTotal) * 100
+  const segments = [...byKind.entries()]
+    .filter(([, n]) => n > 0)
+    .map(([kind, n]) => {
+      const pct = (n / total) * 100
+      return (
+        `<span class="seg" style="width:${pct.toFixed(2)}%;background:${kindColor(kind)}" ` +
+        `title="${escapeHtml(kindLabel(kind))}：${n}"></span>`
+      )
+    })
+    .join('')
+  return `<div class="bar" style="width:${widthPct.toFixed(2)}%">${segments}</div>`
+}
+
+function buildHtml(input: {
+  logs: LogRow[]
+  blacklist: BlacklistRow[]
+  totalLogCount: number
+  generatedAt: number
+}): string {
+  const { logs, blacklist, totalLogCount, generatedAt } = input
+
+  // 聚合（皆以撈取到的最近 REPORT_MAX_ROWS 筆為範圍）。
+  const uniqueKeys = new Set(logs.map((r) => r.key))
+  const last24h = logs.filter((r) => generatedAt - r.created_at <= 86_400_000).length
+
+  const kindCounts = new Map<string, number>()
+  const pathCounts = new Map<string, number>()
+  for (const r of logs) {
+    kindCounts.set(r.kind, (kindCounts.get(r.kind) ?? 0) + 1)
+    pathCounts.set(r.path, (pathCounts.get(r.path) ?? 0) + 1)
+  }
+
+  // 每日趨勢（近 REPORT_DAYS 天，含當天；以報表時區切日）。
+  const days: string[] = []
+  for (let i = REPORT_DAYS - 1; i >= 0; i--) {
+    days.push(toLocalDate(generatedAt - i * 86_400_000))
+  }
+  const daily = new Map<string, Map<string, number>>(days.map((d) => [d, new Map()]))
+  for (const r of logs) {
+    const day = toLocalDate(r.created_at)
+    const bucket = daily.get(day)
+    if (bucket) bucket.set(r.kind, (bucket.get(r.kind) ?? 0) + 1)
+  }
+  const dailyTotals = days.map((d) => {
+    const bucket = daily.get(d) ?? new Map<string, number>()
+    return { day: d, byKind: bucket, total: [...bucket.values()].reduce((a, b) => a + b, 0) }
+  })
+  const maxDaily = Math.max(1, ...dailyTotals.map((d) => d.total))
+
+  // Top offenders。
+  type Offender = { key: string; total: number; byKind: Map<string, number>; lastAt: number }
+  const offenderMap = new Map<string, Offender>()
+  for (const r of logs) {
+    const o = offenderMap.get(r.key) ?? { key: r.key, total: 0, byKind: new Map(), lastAt: 0 }
+    o.total += 1
+    o.byKind.set(r.kind, (o.byKind.get(r.kind) ?? 0) + 1)
+    o.lastAt = Math.max(o.lastAt, r.created_at)
+    offenderMap.set(r.key, o)
+  }
+  const offenders = [...offenderMap.values()]
+    .sort((a, b) => b.total - a.total || b.lastAt - a.lastAt)
+    .slice(0, TOP_OFFENDERS_LIMIT)
+  const maxOffender = Math.max(1, ...offenders.map((o) => o.total))
+  const blacklistedKeys = new Set(blacklist.map((b) => b.key))
+
+  const recent = logs.slice(0, RECENT_TABLE_LIMIT)
+
+  const legend = Object.keys(KIND_LABELS)
+    .map(
+      (kind) =>
+        `<span class="legend-item"><span class="dot" style="background:${kindColor(kind)}"></span>${escapeHtml(kindLabel(kind))}</span>`,
+    )
+    .join('')
+
+  const truncatedNote =
+    totalLogCount > logs.length
+      ? `<p class="note">⚠️ log 共 ${totalLogCount} 筆，本報告僅分析最近 ${logs.length} 筆（REPORT_MAX_ROWS=${REPORT_MAX_ROWS}）。</p>`
+      : ''
+
+  return `<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>異常請求分析報告 — ${escapeHtml(D1_DATABASE)}</title>
+<style>
+  :root { color-scheme: light; }
+  body { font-family: -apple-system, "Noto Sans TC", "PingFang TC", sans-serif;
+         margin: 0; background: #f5f6f8; color: #1c2330; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 24px 20px 64px; }
+  h1 { font-size: 1.5rem; margin: 0 0 4px; }
+  h2 { font-size: 1.1rem; margin: 36px 0 12px; border-left: 4px solid #2e86ab; padding-left: 8px; }
+  .meta { color: #5b6575; font-size: .85rem; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 16px; }
+  .card { background: #fff; border-radius: 10px; padding: 14px 16px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+  .card .num { font-size: 1.7rem; font-weight: 700; }
+  .card .label { color: #5b6575; font-size: .85rem; margin-top: 2px; }
+  table { border-collapse: collapse; width: 100%; background: #fff; border-radius: 10px;
+          overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); font-size: .88rem; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #eef0f3; vertical-align: top; }
+  th { background: #eef3f7; font-weight: 600; white-space: nowrap; }
+  tr:last-child td { border-bottom: none; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  code { background: #f0f2f5; border-radius: 4px; padding: 1px 5px; font-size: .85em; word-break: break-all; }
+  .chart { background: #fff; border-radius: 10px; padding: 14px 16px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+  .chart-row { display: grid; grid-template-columns: 96px 1fr 48px; gap: 8px; align-items: center; margin: 4px 0; }
+  .chart-row .day { font-size: .82rem; color: #5b6575; font-variant-numeric: tabular-nums; }
+  .chart-row .count { font-size: .82rem; text-align: right; font-variant-numeric: tabular-nums; }
+  .track { background: #f0f2f5; border-radius: 4px; min-height: 16px; }
+  .bar { display: flex; height: 16px; border-radius: 4px; overflow: hidden; min-width: 2px; }
+  .seg { display: block; height: 100%; }
+  .legend { margin: 10px 0 0; font-size: .82rem; color: #5b6575; }
+  .legend-item { margin-right: 16px; }
+  .dot { display: inline-block; width: 10px; height: 10px; border-radius: 3px; margin-right: 5px; vertical-align: -1px; }
+  .badge { display: inline-block; background: #c0392b; color: #fff; border-radius: 4px;
+           font-size: .72rem; padding: 1px 6px; margin-left: 6px; vertical-align: 1px; }
+  .note { color: #8a6d1a; background: #fff8e1; border-radius: 8px; padding: 10px 12px; font-size: .85rem; }
+  .empty { color: #5b6575; background: #fff; border-radius: 10px; padding: 14px 16px;
+           box-shadow: 0 1px 3px rgba(0,0,0,.08); font-size: .9rem; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>異常請求分析報告</h1>
+  <p class="meta">資料庫：<code>${escapeHtml(D1_DATABASE)}</code>（${D1_FLAG === '--local' ? '本機' : '遠端'}）
+    ｜產生時間：${toLocalDateTime(generatedAt)}（UTC${TZ_OFFSET_HOURS >= 0 ? '+' : ''}${TZ_OFFSET_HOURS}）</p>
+  ${truncatedNote}
+
+  <div class="cards">
+    <div class="card"><div class="num">${totalLogCount}</div><div class="label">異常事件總數</div></div>
+    <div class="card"><div class="num">${last24h}</div><div class="label">近 24 小時事件</div></div>
+    <div class="card"><div class="num">${uniqueKeys.size}</div><div class="label">不同來源（key）數</div></div>
+    <div class="card"><div class="num">${blacklist.length}</div><div class="label">黑名單筆數</div></div>
+  </div>
+
+  <h2>每日事件數（近 ${REPORT_DAYS} 天）</h2>
+  <div class="chart">
+    ${dailyTotals
+      .map(
+        (d) => `<div class="chart-row">
+      <span class="day">${d.day}</span>
+      <span class="track">${renderStackedBar(d.byKind, d.total, maxDaily)}</span>
+      <span class="count">${d.total}</span>
+    </div>`,
+      )
+      .join('\n    ')}
+    <div class="legend">${legend}</div>
+  </div>
+
+  <h2>異常類型與路徑分佈</h2>
+  <table>
+    <tr><th>異常類型</th><th class="num">次數</th><th>路徑</th><th class="num">次數</th></tr>
+    ${(() => {
+      const kinds = [...kindCounts.entries()].sort((a, b) => b[1] - a[1])
+      const paths = [...pathCounts.entries()].sort((a, b) => b[1] - a[1])
+      const rows = Math.max(kinds.length, paths.length, 1)
+      const cells: string[] = []
+      for (let i = 0; i < rows; i++) {
+        const k = kinds[i]
+        const p = paths[i]
+        cells.push(
+          `<tr><td>${k ? escapeHtml(kindLabel(k[0])) : ''}</td><td class="num">${k ? k[1] : ''}</td>` +
+            `<td>${p ? `<code>/${escapeHtml(p[0])}</code>` : ''}</td><td class="num">${p ? p[1] : ''}</td></tr>`,
+        )
+      }
+      return cells.join('\n    ')
+    })()}
+  </table>
+
+  <h2>最常觸發的來源（Top ${TOP_OFFENDERS_LIMIT}）</h2>
+  ${
+    offenders.length === 0
+      ? '<div class="empty">（無資料）</div>'
+      : `<table>
+    <tr><th>來源 key</th><th class="num">次數</th><th style="width:30%">分佈</th><th>最後發生</th></tr>
+    ${offenders
+      .map(
+        (o) => `<tr>
+      <td><code>${escapeHtml(o.key)}</code>${blacklistedKeys.has(o.key) ? '<span class="badge">黑名單</span>' : ''}</td>
+      <td class="num">${o.total}</td>
+      <td><span class="track" style="display:block">${renderStackedBar(o.byKind, o.total, maxOffender)}</span></td>
+      <td>${toLocalDateTime(o.lastAt)}</td>
+    </tr>`,
+      )
+      .join('\n    ')}
+  </table>`
+  }
+
+  <h2>黑名單（${blacklist.length} 筆）</h2>
+  ${
+    blacklist.length === 0
+      ? '<div class="empty">（目前沒有黑名單）</div>'
+      : `<table>
+    <tr><th>來源 key</th><th>觸發原因</th><th class="num">當下累計</th><th>寫入時間</th></tr>
+    ${blacklist
+      .map(
+        (b) => `<tr>
+      <td><code>${escapeHtml(b.key)}</code></td>
+      <td>${escapeHtml(kindLabel(b.reason))}</td>
+      <td class="num">${b.offense_count}</td>
+      <td>${toLocalDateTime(b.created_at)}</td>
+    </tr>`,
+      )
+      .join('\n    ')}
+  </table>
+  <p class="meta" style="margin-top:8px">解除封鎖：<code>npm run abuse:unban -- &lt;key&gt;</code>（會同時清掉該 key 的 log 舊紀錄）</p>`
+  }
+
+  <h2>最近 ${recent.length} 筆事件</h2>
+  ${
+    recent.length === 0
+      ? '<div class="empty">（無資料）</div>'
+      : `<table>
+    <tr><th>時間</th><th>來源 key</th><th>類型</th><th>路徑</th><th>問題（截斷）</th><th>IP / LINE Id</th></tr>
+    ${recent
+      .map(
+        (r) => `<tr>
+      <td style="white-space:nowrap">${toLocalDateTime(r.created_at)}</td>
+      <td><code>${escapeHtml(r.key)}</code></td>
+      <td style="white-space:nowrap"><span class="dot" style="background:${kindColor(r.kind)}"></span>${escapeHtml(kindLabel(r.kind))}</td>
+      <td style="white-space:nowrap"><code>/${escapeHtml(r.path)}</code></td>
+      <td>${escapeHtml(clipText(r.question, 80))}</td>
+      <td>${escapeHtml(r.ip ?? r.line_id ?? '')}</td>
+    </tr>`,
+      )
+      .join('\n    ')}
+  </table>`
+  }
+</div>
+</body>
+</html>
+`
+}
+
+// ── 主流程 ───────────────────────────────────────────────────────────────────
+async function main() {
+  console.log(`[abuse-report] 從 D1 (${D1_FLAG}) ${D1_DATABASE} 撈取資料…`)
+
+  const totalRow = d1Query('SELECT COUNT(*) AS n FROM abuse_log')
+  const totalLogCount = Number(totalRow[0]?.n ?? 0)
+
+  const logs = d1Query(
+    'SELECT key, kind, path, question, ip, line_id, created_at FROM abuse_log ' +
+      `ORDER BY created_at DESC LIMIT ${REPORT_MAX_ROWS}`,
+  ) as unknown as LogRow[]
+
+  const blacklist = d1Query(
+    'SELECT key, reason, offense_count, created_at FROM blacklist ORDER BY created_at DESC',
+  ) as unknown as BlacklistRow[]
+
+  console.log(
+    `[abuse-report] log ${totalLogCount} 筆（分析最近 ${logs.length} 筆）、黑名單 ${blacklist.length} 筆`,
+  )
+
+  const html = buildHtml({ logs, blacklist, totalLogCount, generatedAt: Date.now() })
+  await mkdir(path.dirname(OUT_PATH), { recursive: true })
+  await writeFile(OUT_PATH, html)
+  console.log(`[abuse-report] 報告已輸出：${OUT_PATH}`)
+}
+
+main().catch((err) => {
+  console.error('[abuse-report] Fatal:', err instanceof Error ? err.message : err)
+  process.exitCode = 1
+})

--- a/scripts/abuse-unban.ts
+++ b/scripts/abuse-unban.ts
@@ -1,0 +1,54 @@
+/**
+ * Issue #27 — 把指定 key 從黑名單移除。
+ *
+ * 會「同時」刪除該 key 在 abuse_log 的舊紀錄：因為黑名單門檻是以 log 計數判斷，
+ * 若只刪黑名單、留著 log，該 key 下次再觸發一次異常就會立刻回到黑名單。
+ *
+ * 用法（從 repo 根目錄）：
+ *   npm run abuse:unban -- ip:1.2.3.4
+ *   npm run abuse:unban -- line:U1234567890abcdef
+ *   LOCAL=1 npm run abuse:unban -- ip:1.2.3.4    # 本機 wrangler dev 的 D1
+ *
+ * 選填環境變數：
+ *   ABUSE_D1_DATABASE   D1 資料庫名（預設 askit-abuse-log）
+ */
+import { execSync } from 'node:child_process'
+
+const D1_DATABASE = process.env.ABUSE_D1_DATABASE ?? 'askit-abuse-log'
+const D1_FLAG = process.env.LOCAL === '1' ? '--local' : '--remote'
+
+// 合法 key 形態：ip:1.2.3.4、ip6:1a2b:3c4d:5e6f:7a8b::/64、line:U…、line:group:C…。
+// 白名單字元（含 : . / -），其餘一律拒絕（防 SQL 注入；wrangler CLI 無 bind 參數可用）。
+const KEY_RE = /^[A-Za-z0-9:./_-]+$/
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+function d1Command(sql: string): void {
+  const cmd =
+    `npx wrangler d1 execute ${shellQuote(D1_DATABASE)} ${D1_FLAG} ` +
+    `--command ${shellQuote(sql)} --yes`
+  execSync(cmd, { stdio: 'inherit' })
+}
+
+const key = process.argv[2]
+if (!key) {
+  console.error('用法：npm run abuse:unban -- <key>（例如 ip:1.2.3.4、line:U…）')
+  process.exit(1)
+}
+if (!KEY_RE.test(key)) {
+  console.error(`key 含有不允許的字元：${key}`)
+  process.exit(1)
+}
+
+console.log(`[abuse-unban] 從 D1 (${D1_FLAG}) ${D1_DATABASE} 移除 ${key} …`)
+d1Command(
+  `DELETE FROM blacklist WHERE key = ${sqlString(key)}; ` +
+    `DELETE FROM abuse_log WHERE key = ${sqlString(key)};`,
+)
+console.log(`[abuse-unban] 完成。${key} 已自黑名單與 abuse_log 移除。`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ const NOT_FOUND_REPLY = '您的問題超出了資料庫的範圍，\n逐字稿�
 const ERROR_REPLY = '查詢發生錯誤，請稍後再試'
 // 限流冷卻視窗：同一使用者於此毫秒數內最多 1 次（對齊首頁送出鈕的 10 秒冷卻）。
 const RATE_LIMIT_WINDOW_MS = 10_000
+const NOT_FOUND_REPLY_MIN_DELAY_MS = RATE_LIMIT_WINDOW_MS
 const GLOBAL_GENERATION_LIMIT_PER_MINUTE = 15
 const GLOBAL_GENERATION_LIMIT_PER_DAY = 300
 const MAX_QUESTION_CHARS = 100
@@ -297,6 +298,18 @@ function isCacheableCagAnswerText(text: string): boolean {
   return !knownBadAnswerPhrases.some((phrase) => normalized.includes(phrase))
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function delayUntilMinimumElapsed(
+  startedAt: number,
+  minElapsedMs = NOT_FOUND_REPLY_MIN_DELAY_MS,
+): Promise<void> {
+  const remainingMs = minElapsedMs - (Date.now() - startedAt)
+  if (remainingMs > 0) await sleep(remainingMs)
+}
+
 // 用快取內容組出回應（命中時走這條，不跑檢索與 AI）。
 function respondFromCache(body: string, contentType: string): Response {
   return new Response(body, {
@@ -305,26 +318,31 @@ function respondFromCache(body: string, contentType: string): Response {
   })
 }
 
-// 把串流回應「分流」：一份照常串給使用者，一份在背景累積成完整文字後寫入快取。
-// 只快取 200 成功回應；非 200（如 404 查無範圍）或無 body 時原樣回傳、不快取。
-function cacheStreamingResponse(
+// CAG 成功文字才快取；查無結果或模型答不出時，補足限流冷卻時間再回覆，
+// 避免使用者在看到失敗訊息後立刻重試而誤觸同一個 10 秒限流視窗。
+async function cacheCagResponse(
   c: Context<{ Bindings: Bindings }>,
   cacheKey: string,
   response: Response,
-): Response {
-  if (response.status !== 200 || !response.body) return response
-  const [toClient, toCache] = response.body.tee()
+  startedAt: number,
+): Promise<Response> {
+  if (response.status !== 200 || !response.body) {
+    if (response.status === 404) await delayUntilMinimumElapsed(startedAt)
+    return response
+  }
+
   const contentType =
     response.headers.get('Content-Type') || 'text/markdown; charset=UTF-8'
-  c.executionCtx.waitUntil(
-    readStreamToString(toCache)
-      .then((text) => {
-        if (!isCacheableCagAnswerText(text)) return
-        return putCachedResponse(c.env.ASK_CACHE, cacheKey, text, contentType)
-      })
-      .catch((e) => console.error('快取串流寫入失敗:', e)),
-  )
-  return new Response(toClient, {
+  const text = await readStreamToString(response.body)
+  if (isCacheableCagAnswerText(text)) {
+    c.executionCtx.waitUntil(
+      putCachedResponse(c.env.ASK_CACHE, cacheKey, text, contentType)
+        .catch((e) => console.error('快取 CAG 回應失敗:', e)),
+    )
+  } else {
+    await delayUntilMinimumElapsed(startedAt)
+  }
+  return new Response(text, {
     status: response.status,
     headers: response.headers,
   })
@@ -633,11 +651,13 @@ async function replyWithFuseFallback(
   env: Bindings,
   replyToken: string,
   question: string,
+  startedAt: number,
 ): Promise<void> {
   try {
     const hits = await findClosestMatchingSections(env.ASK_INDEX, question, {
       limit: 2,
     })
+    if (hits.length === 0) await delayUntilMinimumElapsed(startedAt)
     await replyToLine(
       env,
       replyToken,
@@ -681,6 +701,7 @@ async function replyWithCag(
   replyToken: string,
   userId: string | undefined,
   question: string,
+  startedAt: number,
 ): Promise<void> {
   const retriever = resolveCagRetriever(env.CAG_RETRIEVER)
   const model = env.ASK_MODEL || DEFAULT_CAG_MODEL
@@ -731,21 +752,28 @@ async function replyWithCag(
 
   if (!cag || cag.answer.trim() === '') {
     if (!cagFailed && retriever === 'vectorize' && env.VECTORIZE) {
+      await delayUntilMinimumElapsed(startedAt)
       await replyToLine(env, replyToken, { type: 'text', text: NOT_FOUND_REPLY })
       return
     }
-    await replyWithFuseFallback(env, replyToken, question)
+    await replyWithFuseFallback(env, replyToken, question, startedAt)
     return
   }
   const answer = splitSentencesToLines(trimToCompleteSentence(cag.answer))
+  const cacheable = isCacheableCagAnswerText(answer)
+  if (!cacheable) {
+    await delayUntilMinimumElapsed(startedAt)
+  }
   await replyToLine(env, replyToken, formatCagAnswerFlex(answer, cag.sources))
   // 成功生成才寫入快取（answer + sources），供下次相同問題直接取用。
-  await putCachedResponse(
-    env.ASK_CACHE,
-    cacheKey,
-    JSON.stringify({ answer, sources: cag.sources }),
-    'application/json; charset=UTF-8',
-  )
+  if (cacheable) {
+    await putCachedResponse(
+      env.ASK_CACHE,
+      cacheKey,
+      JSON.stringify({ answer, sources: cag.sources }),
+      'application/json; charset=UTF-8',
+    )
+  }
 }
 
 app.get('/', (c) => {
@@ -769,6 +797,7 @@ app.get('/robots.txt', (c) => {
 })
 
 app.get('/ask/:question', async (c) => {
+  const startedAt = Date.now()
   const question = decodeRouteParam(c.req.param('question'))
   // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
   const abuse = await checkHttpBlacklist(c)
@@ -807,6 +836,7 @@ app.get('/ask/:question', async (c) => {
       ? await findRandomSection(c.env.ASK_INDEX)
       : await findClosestMatchingSection(c.env.ASK_INDEX, question)
     if (!hit) {
+      await delayUntilMinimumElapsed(startedAt)
       return c.text('您的問題超出了資料庫的範圍，\n逐字稿網站連結如下：https://archive.tw', 404)
     }
     const body = formatAskAnswerHtml(hit)
@@ -841,6 +871,7 @@ app.get('/cag/status', (c) => {
 })
 
 app.get('/cag/:question', async (c) => {
+  const startedAt = Date.now()
   const question = decodeRouteParam(c.req.param('question'))
   // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
   const abuse = await checkHttpBlacklist(c)
@@ -904,10 +935,11 @@ app.get('/cag/:question', async (c) => {
   }
 
   const response = await streamCagAnswer(c.env.AI, question, cagOptions)
-  return cacheStreamingResponse(c, cacheKey, response)
+  return cacheCagResponse(c, cacheKey, response, startedAt)
 })
 
 app.post('/cag', async (c) => {
+  const startedAt = Date.now()
   // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
   const abuse = await checkHttpBlacklist(c)
   if (abuse.blocked) {
@@ -1008,10 +1040,11 @@ app.post('/cag', async (c) => {
   }
 
   const response = await streamCagAnswer(c.env.AI, question, cagOptions)
-  return cacheStreamingResponse(c, cacheKey, response)
+  return cacheCagResponse(c, cacheKey, response, startedAt)
 })
 
 app.post('/webhook', async (c) => {
+  const startedAt = Date.now()
   const rawBody = await c.req.text()
   const signature = c.req.header('x-line-signature')
 
@@ -1075,7 +1108,7 @@ app.post('/webhook', async (c) => {
   // 關鍵：CAG 生成需數秒到十幾秒，超過 LINE 對 webhook 的「2 秒內回 2xx」限制，
   // 因此把慢工作交給 ctx.waitUntil 背景執行（回應後最多 30 秒預算），handler 立刻 ack。
   // reply token 約 1 分鐘有效，留待背景用 Reply API 送出「唯一一次」回覆。
-  c.executionCtx.waitUntil(replyWithCag(c.env, replyToken, userId, userText))
+  c.executionCtx.waitUntil(replyWithCag(c.env, replyToken, userId, userText, startedAt))
 
   return c.text('OK', 200)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,15 @@ import { renderHomePage } from './pages/home'
 import { renderPrivacyPolicyPage } from './pages/privacy'
 import { renderTermsOfUsePage } from './pages/terms'
 import {
+  type AbuseKind,
+  type AbusePath,
+  type AbuseThresholdOptions,
+  DEFAULT_ABUSE_BLACKLIST_THRESHOLD,
+  DEFAULT_ABUSE_COUNT_WINDOW_HOURS,
+  isBlacklisted,
+  recordAbuse,
+} from './utils/abuse'
+import {
   type CagAnswer,
   type CagRetriever,
   type CagSource,
@@ -66,6 +75,11 @@ type Bindings = {
   // 任一未綁時，該層自動跳過（dev/測試仍可運作）。
   RATE_LIMITER?: RateLimiter
   RATE_LIMIT_DO?: DurableObjectNamespace
+  // 超量／異常請求追蹤 log 與黑名單（issue #27）。未綁時優雅降級：
+  // 不寫 log、黑名單視為空，請求照常處理。
+  ABUSE_DB?: D1Database
+  ABUSE_BLACKLIST_THRESHOLD?: string
+  ABUSE_COUNT_WINDOW_HOURS?: string
 }
 
 const DEFAULT_CAG_RETRIEVER: CagRetriever = 'vectorize'
@@ -133,6 +147,8 @@ const RATE_LIMIT_LINE_REPLY = '您的發問過於頻繁，請稍候約 10 秒再
 const GLOBAL_BUDGET_HTTP_MESSAGE = '目前服務量已達上限，請稍後再試，謝謝'
 const GLOBAL_BUDGET_LINE_REPLY = '目前服務量已達上限，請稍後再試，謝謝'
 const QUESTION_TOO_LONG_MESSAGE = '您的問題字數過長，請縮短問題的長度，謝謝!'
+// 黑名單成員的回覆（issue #27）。LINE 來源被封鎖時不回覆、僅 ack。
+const BLACKLISTED_HTTP_MESSAGE = '由於多次異常請求，您的存取已被暫停'
 const ROBOTS_TXT = `User-agent: *
 Disallow: /ask/
 Disallow: /cag/
@@ -412,6 +428,79 @@ async function isIpRateLimited(c: Context<{ Bindings: Bindings }>): Promise<bool
   return isRateLimited(c.env, ipRateLimitKeyFromIp(ip))
 }
 
+// ── 異常請求追蹤與黑名單（issue #27）────────────────────────────────────────
+// 「單一 IP/Id 超量」或「問題字串過長」時寫入 abuse_log；同一 key 在視窗內
+// 累積達門檻次數即自動進黑名單。黑名單比對放在「任何 DO/KV 限流記帳之前」，
+// 被封鎖的請求完全不消耗全域生成額度，以保障善意使用者。
+
+function resolveAbuseOptions(env: Bindings): AbuseThresholdOptions {
+  const threshold = parsePositiveInteger(
+    env.ABUSE_BLACKLIST_THRESHOLD,
+    DEFAULT_ABUSE_BLACKLIST_THRESHOLD,
+  )
+  const windowHours = parseOptionalNumber(env.ABUSE_COUNT_WINDOW_HOURS)
+  const hours =
+    windowHours !== undefined && windowHours >= 0
+      ? windowHours
+      : DEFAULT_ABUSE_COUNT_WINDOW_HOURS
+  return { threshold, windowMs: Math.round(hours * 3_600_000) }
+}
+
+// 在背景寫入異常紀錄（waitUntil），不增加回應延遲；key 取不到時略過。
+function reportAbuse(
+  c: Context<{ Bindings: Bindings }>,
+  entry: {
+    key: string | null
+    kind: AbuseKind
+    path: AbusePath
+    question: string
+    ip?: string
+    lineId?: string
+  },
+): void {
+  const { key, ...rest } = entry
+  if (!key) return
+  c.executionCtx.waitUntil(
+    recordAbuse(c.env.ABUSE_DB, { key, ...rest }, resolveAbuseOptions(c.env)),
+  )
+}
+
+type HttpAbuseIdentity = {
+  ip?: string
+  key: string | null
+  blocked: boolean
+}
+
+// 網頁/API 路徑以 IP 為身分做黑名單比對（與限流 key 同一套；IPv6 收斂到 /64）。
+// 取不到 IP（本機 wrangler dev）時不比對、不記錄。
+async function checkHttpBlacklist(
+  c: Context<{ Bindings: Bindings }>,
+): Promise<HttpAbuseIdentity> {
+  const ip = c.req.header('cf-connecting-ip')
+  const key = ip ? ipRateLimitKeyFromIp(ip) : null
+  if (!key) return { ip, key, blocked: false }
+  return { ip, key, blocked: await isBlacklisted(c.env.ABUSE_DB, key) }
+}
+
+// LINE 來源的異常記錄。anonymous 桶可能混雜多個無法識別的使用者，
+// 不自動記錄（否則 3 個不同人的異常會讓所有匿名事件一起被封鎖）。
+function reportLineAbuse(
+  c: Context<{ Bindings: Bindings }>,
+  source: LineMessageEvent['source'],
+  kind: AbuseKind,
+  question: string,
+): void {
+  const key = lineRateLimitKey(source)
+  if (key === 'line:anonymous') return
+  reportAbuse(c, {
+    key,
+    kind,
+    path: 'webhook',
+    question,
+    lineId: source.userId ?? source.groupId ?? source.roomId,
+  })
+}
+
 async function checkGlobalGenerationBudget(
   env: Bindings,
 ): Promise<BudgetLimitDecision> {
@@ -680,11 +769,18 @@ app.get('/robots.txt', (c) => {
 })
 
 app.get('/ask/:question', async (c) => {
+  const question = decodeRouteParam(c.req.param('question'))
+  // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
+  const abuse = await checkHttpBlacklist(c)
+  if (abuse.blocked) {
+    return c.text(BLACKLISTED_HTTP_MESSAGE, 403)
+  }
   if (await isIpRateLimited(c)) {
+    reportAbuse(c, { key: abuse.key, kind: 'rate_limit', path: 'ask', question, ip: abuse.ip })
     return c.text(RATE_LIMIT_HTTP_MESSAGE, 429, { 'Retry-After': '10' })
   }
-  const question = decodeRouteParam(c.req.param('question'))
   if (isQuestionTooLong(question)) {
+    reportAbuse(c, { key: abuse.key, kind: 'question_too_long', path: 'ask', question, ip: abuse.ip })
     return c.text(QUESTION_TOO_LONG_MESSAGE, 400)
   }
   // 隨機問題每次都要不同結果，不快取；其餘相同問題 7 天內直接取用。
@@ -745,11 +841,18 @@ app.get('/cag/status', (c) => {
 })
 
 app.get('/cag/:question', async (c) => {
+  const question = decodeRouteParam(c.req.param('question'))
+  // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
+  const abuse = await checkHttpBlacklist(c)
+  if (abuse.blocked) {
+    return c.text(BLACKLISTED_HTTP_MESSAGE, 403)
+  }
   if (await isIpRateLimited(c)) {
+    reportAbuse(c, { key: abuse.key, kind: 'rate_limit', path: 'cag', question, ip: abuse.ip })
     return c.text(RATE_LIMIT_HTTP_MESSAGE, 429, { 'Retry-After': '10' })
   }
-  const question = decodeRouteParam(c.req.param('question'))
   if (isQuestionTooLong(question)) {
+    reportAbuse(c, { key: abuse.key, kind: 'question_too_long', path: 'cag', question, ip: abuse.ip })
     return c.text(QUESTION_TOO_LONG_MESSAGE, 400)
   }
   const model = c.env.ASK_MODEL || DEFAULT_CAG_MODEL
@@ -805,7 +908,27 @@ app.get('/cag/:question', async (c) => {
 })
 
 app.post('/cag', async (c) => {
+  // 黑名單比對在任何 DO/KV 限流記帳之前（issue #27）。
+  const abuse = await checkHttpBlacklist(c)
+  if (abuse.blocked) {
+    return c.text(BLACKLISTED_HTTP_MESSAGE, 403)
+  }
   if (await isIpRateLimited(c)) {
+    // body 已被 maxApiBodySize 中介層緩衝在記憶體，best-effort 解析問題供記錄。
+    let loggedQuestion = ''
+    try {
+      const body = (await c.req.json()) as { question?: unknown }
+      if (typeof body.question === 'string') loggedQuestion = body.question
+    } catch {
+      // 解析失敗就記空問題。
+    }
+    reportAbuse(c, {
+      key: abuse.key,
+      kind: 'rate_limit',
+      path: 'cag',
+      question: loggedQuestion,
+      ip: abuse.ip,
+    })
     return c.text(RATE_LIMIT_HTTP_MESSAGE, 429, { 'Retry-After': '10' })
   }
   let payload: { question?: unknown; topK?: unknown; top_k?: unknown; citableTopK?: unknown; cite_top_k?: unknown; maxTokens?: unknown; max_tokens?: unknown; retriever?: unknown; minScore?: unknown; min_score?: unknown }
@@ -820,6 +943,7 @@ app.post('/cag', async (c) => {
     return c.text('question is required', 400)
   }
   if (isQuestionTooLong(question)) {
+    reportAbuse(c, { key: abuse.key, kind: 'question_too_long', path: 'cag', question, ip: abuse.ip })
     return c.text(QUESTION_TOO_LONG_MESSAGE, 400)
   }
 
@@ -923,7 +1047,14 @@ app.post('/webhook', async (c) => {
   const userId = event.source.userId
   const userText = event.message.text ?? ''
 
+  // 黑名單成員直接 ack 後丟棄（issue #27）：不回覆、不做任何 DO/KV 限流記帳，
+  // 完全不消耗全域生成額度。回 200 是為了避免 LINE 平台重送同一事件。
+  if (await isBlacklisted(c.env.ABUSE_DB, lineRateLimitKey(event.source))) {
+    return c.text('OK', 200)
+  }
+
   if (isQuestionTooLong(userText)) {
+    reportLineAbuse(c, event.source, 'question_too_long', userText)
     c.executionCtx.waitUntil(
       replyToLine(c.env, replyToken, { type: 'text', text: QUESTION_TOO_LONG_MESSAGE }),
     )
@@ -934,6 +1065,7 @@ app.post('/webhook', async (c) => {
   // userId 缺席時改以 groupId / roomId / anonymous 做較粗的限流，避免群組事件繞過。
   // （仍須回 200 ack，並用一次性 reply token 送出提示。）
   if (await isRateLimited(c.env, lineRateLimitKey(event.source))) {
+    reportLineAbuse(c, event.source, 'rate_limit', userText)
     c.executionCtx.waitUntil(
       replyToLine(c.env, replyToken, { type: 'text', text: RATE_LIMIT_LINE_REPLY }),
     )

--- a/src/utils/abuse.ts
+++ b/src/utils/abuse.ts
@@ -1,0 +1,112 @@
+// Issue #27 — 對超量或異常的請求建立 D1 追蹤 log 與黑名單。
+//
+// 兩張表（schema 見 db/abuse-log-schema.sql）：
+//   - abuse_log：每次「單一 IP/Id 超量」（rate_limit）或「問題字串過長」
+//     （question_too_long）自動寫入一筆。全域配額用罄不算異常、不寫入。
+//   - blacklist：同一 key 在計數視窗（預設 24 小時）內累積達門檻（預設 3）次
+//     異常時，於同一個 batch 交易內自動寫入。
+//
+// 黑名單比對發生在「任何 DO/KV 限流記帳之前」：被封鎖的請求直接擋下，
+// 不消耗全域生成額度，以保障善意使用者（呼叫端見 src/index.ts）。
+//
+// 與專案其他基礎設施一致的優雅降級：ABUSE_DB 未綁（dev／測試）或讀寫發生錯誤時，
+// 黑名單視為未命中、寫 log 靜默略過，絕不讓追蹤機制阻斷正常請求。
+
+export type AbuseKind = 'rate_limit' | 'question_too_long'
+export type AbusePath = 'ask' | 'cag' | 'webhook'
+
+export type AbuseLogEntry = {
+  /** 正規化身分 key（ip:…／ip6:…／line:…），與限流 key 同一套，方便比對。 */
+  key: string
+  kind: AbuseKind
+  path: AbusePath
+  question: string
+  /** 來源 IP（網頁/API 若有；LINE 事件拿不到使用者 IP）。 */
+  ip?: string
+  /** LINE userId 或 groupId/roomId（若有）。 */
+  lineId?: string
+}
+
+export type AbuseThresholdOptions = {
+  /** 視窗內累積達此次數即寫入黑名單。 */
+  threshold: number
+  /** 計數視窗（毫秒）；0 = 不限視窗、全期間計數。 */
+  windowMs: number
+}
+
+export const DEFAULT_ABUSE_BLACKLIST_THRESHOLD = 3
+// issue 原文只說「出現大於等於 3 次」未指定視窗；預設以 24 小時視窗計數，
+// 避免偶爾連發兩則訊息的善意使用者因「終生累計」3 次就被永久封鎖。
+// 設 ABUSE_COUNT_WINDOW_HOURS=0 可改為全期間累計（嚴格按 issue 字面）。
+export const DEFAULT_ABUSE_COUNT_WINDOW_HOURS = 24
+/** log 內 question 欄位的長度上限（碼點）：超長攻擊字串只留頭部供分析。 */
+export const MAX_LOGGED_QUESTION_CHARS = 200
+
+export function truncateQuestionForLog(question: string): string {
+  const chars = [...question.trim()]
+  if (chars.length <= MAX_LOGGED_QUESTION_CHARS) return chars.join('')
+  return `${chars.slice(0, MAX_LOGGED_QUESTION_CHARS).join('')}…`
+}
+
+// 黑名單比對。每個請求一次 point read；查詢失敗時 fail-open（視為未在黑名單），
+// 寧可放過也不誤擋。
+export async function isBlacklisted(
+  db: D1Database | undefined,
+  key: string,
+): Promise<boolean> {
+  if (!db) return false
+  try {
+    const row = await db
+      .prepare('SELECT key FROM blacklist WHERE key = ?1')
+      .bind(key)
+      .first()
+    return row !== null
+  } catch (e) {
+    console.error('黑名單查詢失敗，視為未在黑名單:', e)
+    return false
+  }
+}
+
+// 寫入一筆異常紀錄，並在同一個 batch 交易內檢查門檻、自動寫入黑名單。
+// 第二句 INSERT…SELECT 的計數包含第一句剛插入的那筆；ON CONFLICT DO NOTHING
+// 讓已在黑名單的 key 重跑安全（理論上不會發生：黑名單成員在更上游就被擋下）。
+export async function recordAbuse(
+  db: D1Database | undefined,
+  entry: AbuseLogEntry,
+  options: AbuseThresholdOptions,
+): Promise<void> {
+  if (!db) return
+  const now = Date.now()
+  const windowStart = options.windowMs > 0 ? now - options.windowMs : 0
+  try {
+    await db.batch([
+      db
+        .prepare(
+          'INSERT INTO abuse_log (key, kind, path, question, ip, line_id, created_at) ' +
+            'VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)',
+        )
+        .bind(
+          entry.key,
+          entry.kind,
+          entry.path,
+          truncateQuestionForLog(entry.question),
+          entry.ip ?? null,
+          entry.lineId ?? null,
+          now,
+        ),
+      // 子查詢先算出視窗內次數，外層 WHERE 過門檻才插入。
+      // （SQLite 的 upsert 文法要求 INSERT…SELECT 帶 WHERE 子句以消除與 join 的歧義。）
+      db
+        .prepare(
+          'INSERT INTO blacklist (key, reason, offense_count, created_at) ' +
+            'SELECT ?1, ?2, cnt, ?3 FROM ' +
+            '(SELECT COUNT(*) AS cnt FROM abuse_log WHERE key = ?1 AND created_at >= ?4) ' +
+            'WHERE cnt >= ?5 ' +
+            'ON CONFLICT(key) DO NOTHING',
+        )
+        .bind(entry.key, entry.kind, now, windowStart, options.threshold),
+    ])
+  } catch (e) {
+    console.error('異常請求 log 寫入失敗，略過:', e)
+  }
+}

--- a/test/abuse.test.ts
+++ b/test/abuse.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import test from 'node:test'
+
+import {
+  DEFAULT_ABUSE_BLACKLIST_THRESHOLD,
+  isBlacklisted,
+  MAX_LOGGED_QUESTION_CHARS,
+  recordAbuse,
+  truncateQuestionForLog,
+} from '../src/utils/abuse'
+
+// 以 node:sqlite 跑「真的」schema 與 SQL：用最小 D1 介面（prepare/bind/first/batch）
+// 包住 DatabaseSync，讓 recordAbuse / isBlacklisted 的 SQL 在真 SQLite 上驗證，
+// 而不是只驗證有呼叫過假物件。D1 的 ?N 參數與 node:sqlite 的位置綁定相容。
+function createSqliteBackedD1() {
+  const db = new DatabaseSync(':memory:')
+  db.exec(readFileSync(path.resolve('db/abuse-log-schema.sql'), 'utf-8'))
+  const d1 = {
+    prepare(sql: string) {
+      return {
+        bind(...params: (string | number | null)[]) {
+          return {
+            async first() {
+              return db.prepare(sql).get(...params) ?? null
+            },
+            run() {
+              db.prepare(sql).run(...params)
+            },
+          }
+        },
+      }
+    },
+    async batch(stmts: { run: () => void }[]) {
+      for (const s of stmts) s.run()
+    },
+  }
+  return { db, d1: d1 as never as D1Database }
+}
+
+const OPTIONS = { threshold: DEFAULT_ABUSE_BLACKLIST_THRESHOLD, windowMs: 24 * 3_600_000 }
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    key: 'ip:1.2.3.4',
+    kind: 'rate_limit' as const,
+    path: 'ask' as const,
+    question: '測試問題',
+    ip: '1.2.3.4',
+    ...overrides,
+  }
+}
+
+test('truncateQuestionForLog 短問題原樣保留、超長截斷加省略號', () => {
+  assert.equal(truncateQuestionForLog('  hello  '), 'hello')
+  const long = 'あ'.repeat(MAX_LOGGED_QUESTION_CHARS + 50)
+  const truncated = truncateQuestionForLog(long)
+  assert.equal([...truncated].length, MAX_LOGGED_QUESTION_CHARS + 1)
+  assert.ok(truncated.endsWith('…'))
+})
+
+test('未綁 ABUSE_DB 時優雅降級：不在黑名單、寫 log 靜默略過', async () => {
+  assert.equal(await isBlacklisted(undefined, 'ip:1.2.3.4'), false)
+  await recordAbuse(undefined, entry(), OPTIONS) // 不應拋出
+})
+
+test('查詢/寫入錯誤時 fail-open，不阻斷請求', async () => {
+  const broken = {
+    prepare() {
+      throw new Error('boom')
+    },
+    async batch() {
+      throw new Error('boom')
+    },
+  } as never as D1Database
+  assert.equal(await isBlacklisted(broken, 'ip:1.2.3.4'), false)
+  await recordAbuse(broken, entry(), OPTIONS) // 不應拋出
+})
+
+test('每筆異常都寫入 abuse_log，欄位完整', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  await recordAbuse(d1, entry({ question: ' 問題A ' }), OPTIONS)
+  const rows = db.prepare('SELECT * FROM abuse_log').all() as Record<string, unknown>[]
+  assert.equal(rows.length, 1)
+  assert.equal(rows[0].key, 'ip:1.2.3.4')
+  assert.equal(rows[0].kind, 'rate_limit')
+  assert.equal(rows[0].path, 'ask')
+  assert.equal(rows[0].question, '問題A')
+  assert.equal(rows[0].ip, '1.2.3.4')
+  assert.equal(rows[0].line_id, null)
+  assert.ok(typeof rows[0].created_at === 'number' && rows[0].created_at > 0)
+})
+
+test('同一 key 達 3 次自動進黑名單，第 3 次之前不進', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  await recordAbuse(d1, entry(), OPTIONS)
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), false)
+  await recordAbuse(d1, entry({ kind: 'question_too_long', path: 'cag' }), OPTIONS)
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), false)
+  await recordAbuse(d1, entry(), OPTIONS)
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), true)
+
+  const bl = db.prepare('SELECT * FROM blacklist').all() as Record<string, unknown>[]
+  assert.equal(bl.length, 1)
+  assert.equal(bl[0].key, 'ip:1.2.3.4')
+  assert.equal(bl[0].reason, 'rate_limit') // 第 3 次（觸發封鎖）的 kind
+  assert.equal(bl[0].offense_count, 3)
+})
+
+test('不同 key 各自計數，互不影響', async () => {
+  const { d1 } = createSqliteBackedD1()
+  await recordAbuse(d1, entry(), OPTIONS)
+  await recordAbuse(d1, entry(), OPTIONS)
+  await recordAbuse(d1, entry({ key: 'line:U123', ip: undefined, lineId: 'U123', path: 'webhook' }), OPTIONS)
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), false)
+  assert.equal(await isBlacklisted(d1, 'line:U123'), false)
+})
+
+test('已在黑名單的 key 再寫入不報錯、黑名單維持一筆（ON CONFLICT DO NOTHING）', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  for (let i = 0; i < 5; i++) await recordAbuse(d1, entry(), OPTIONS)
+  const bl = db.prepare('SELECT * FROM blacklist').all() as Record<string, unknown>[]
+  assert.equal(bl.length, 1)
+  assert.equal(bl[0].offense_count, 3) // 第 3 次寫入當下的累計，之後不再更新
+})
+
+test('視窗外的舊紀錄不列入計數', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  // 直接塞兩筆「視窗外」的舊 log（48 小時前）。
+  const old = Date.now() - 48 * 3_600_000
+  const insert = db.prepare(
+    'INSERT INTO abuse_log (key, kind, path, question, created_at) VALUES (?, ?, ?, ?, ?)',
+  )
+  insert.run('ip:1.2.3.4', 'rate_limit', 'ask', 'q', old)
+  insert.run('ip:1.2.3.4', 'rate_limit', 'ask', 'q', old)
+  // 視窗內第 1 筆（總計第 3 筆）：24 小時視窗內僅 1 筆 → 不封鎖。
+  await recordAbuse(d1, entry(), OPTIONS)
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), false)
+  // windowMs=0（全期間累計）時，同樣的第 4 筆就會達門檻。
+  await recordAbuse(d1, entry(), { ...OPTIONS, windowMs: 0 })
+  assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), true)
+})
+
+test('超長問題寫入 log 前會截斷', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  await recordAbuse(d1, entry({ question: 'x'.repeat(10_000) }), OPTIONS)
+  const row = db.prepare('SELECT question FROM abuse_log').get() as { question: string }
+  assert.equal([...row.question].length, MAX_LOGGED_QUESTION_CHARS + 1)
+})

--- a/test/cag.test.ts
+++ b/test/cag.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
+import type { TestContext } from 'node:test'
 import { runInNewContext } from 'node:vm'
 
 import Fuse from 'fuse.js'
@@ -608,6 +609,28 @@ test('question endpoints reject questions over 100 characters before retrieval o
   assert.equal(aiCalls.length, 0)
 })
 
+test('ask not-found replies wait until the rate-limit cooldown has elapsed', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
+  let settled = false
+  const responsePromise = app
+    .request(
+      `/ask/${encodeURIComponent('zzzzzz')}`,
+      undefined,
+      { ASK_INDEX: createAskIndexBucket() },
+    )
+    .then((response) => {
+      settled = true
+      return response
+    })
+
+  for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  assert.equal(settled, false)
+
+  const response = await resolveAfterCooldown(responsePromise, t)
+  assert.equal(response.status, 404)
+  assert.equal(Date.now(), 10_000)
+})
+
 test('POST APIs reject oversized request bodies', async () => {
   const oversizedQuestion = '長'.repeat(33 * 1024)
 
@@ -674,7 +697,14 @@ test('global generation budget blocks uncached CAG before AI', async () => {
   assert.equal(new URL(quotaUrls[0]).pathname, '/quota')
 })
 
-test('public CAG does not cache blank, short, or known-bad streamed answers', async () => {
+async function resolveAfterCooldown<T>(promise: Promise<T>, t: TestContext): Promise<T> {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  t.mock.timers.tick(10_000)
+  return promise
+}
+
+test('public CAG does not cache blank, short, or known-bad streamed answers', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'Date'], now: 0 })
   const badAnswers = [
     '   ',
     '太短',
@@ -718,7 +748,7 @@ test('public CAG does not cache blank, short, or known-bad streamed answers', as
       CAG_RETRIEVER: 'vectorize',
     }
 
-    const response = await app.request(
+    const responsePromise = app.request(
       '/cag/%E6%B8%AC%E8%A9%A6',
       undefined,
       env,
@@ -730,6 +760,7 @@ test('public CAG does not cache blank, short, or known-bad streamed answers', as
         props: {},
       },
     )
+    const response = await resolveAfterCooldown(responsePromise, t)
 
     assert.equal(response.status, 200)
     await response.text()

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,7 +27,12 @@
     // https://console.cloud.google.com/ai/models/kimi-k2.6/cost-estimation
     // 15 次/分鐘約 <= $0.5，300 次/日約 <= $10。
     "GLOBAL_GENERATION_LIMIT_PER_MINUTE": "15",
-    "GLOBAL_GENERATION_LIMIT_PER_DAY": "300"
+    "GLOBAL_GENERATION_LIMIT_PER_DAY": "300",
+    // 異常請求黑名單（issue #27）：同一 IP/Id 在視窗內累積達門檻次數的
+    // 超量／過長請求，自動寫入黑名單，之後在任何限流記帳之前直接擋下。
+    // 視窗設 "0" = 不限視窗、全期間累計。
+    "ABUSE_BLACKLIST_THRESHOLD": "3",
+    "ABUSE_COUNT_WINDOW_HOURS": "24"
   },
 
   // CPU 上限：避免單次請求異常消耗 Worker CPU；AI/網路等待不計入 CPU time。
@@ -72,6 +77,22 @@
   // 查無結果時 CAG 仍會自動回退 archive.tw 檢索。
   "vectorize": [
     { "binding": "VECTORIZE", "index_name": "askit-audrey-tang" }
+  ],
+
+  // D1（issue #27）：超量／異常請求追蹤 log（abuse_log）與黑名單（blacklist）。
+  // 資料庫已建立（npm run abuse:db:create）；建表／重建 schema：
+  //   npm run abuse:db:init          # 遠端
+  //   npm run abuse:db:init:local    # 本機 wrangler dev 用
+  // 分析報告：npm run abuse:report；解除封鎖：npm run abuse:unban -- <key>
+  // 未綁定時程式優雅降級：不寫 log、黑名單視為空。
+  // 注意：刻意「不」設 remote: true —— 本機 dev 寫本機 D1（與本機限流 DO 一致），
+  // 避免開發測試把雜訊寫進正式環境的 log／黑名單。
+  "d1_databases": [
+    {
+      "binding": "ABUSE_DB",
+      "database_name": "askit-abuse-log",
+      "database_id": "d87861ce-46d5-4053-afdf-abf5c4a9f61c"
+    }
   ],
 
   // 防連續濫用：兩層限流（兩層共用同一個 key：line:<userId>、ip:<IPv4> 或 ip6:<IPv6 /64>）。


### PR DESCRIPTION
Closes #27

## 內容

依 issue 的三個方案實作：

1. **D1 表 `abuse_log`**（追蹤 log）：「單一 IP/Id 觸發限流」（全域配額用罄不算）或「問題字串過長」發生時自動寫入：問題（截斷至 200 碼點）、IP（網頁/API 若有）、LINE userId／groupId（若有）、epoch 毫秒時間戳記，以及與限流同一套的正規化身分 key（`ip:…`／`ip6:…/64`／`line:…`），方便跨路徑比對。
2. **D1 表 `blacklist`**（黑名單）：同一 key 累積達門檻次數時，與寫 log 同一筆 D1 batch 交易自動寫入（`INSERT…SELECT…ON CONFLICT DO NOTHING`，併發安全）。
3. **近端分析腳本** `npm run abuse:report`：撈 D1 資料、本機聚合，產出單檔 HTML 視覺化報告（`build/abuse-report.html`，無外部依賴）：事件總數／近 24h、每日趨勢堆疊長條圖、類型與路徑分佈、Top 20 來源（標示黑名單）、黑名單清單、最近事件明細。

4. /webhook和/fuse對超範圍的回應加入UX拖延，以避免正常使用者連續發問

**黑名單比對在任何 DO/KV 限流記帳之前**：`/ask`、`/cag`（GET/POST）回 `403`；LINE webhook 僅 ack 200 不回覆（避免平台重送），完全不消耗全域生成額度，以保障善意使用者。

## 與 issue 字面的一個刻意差異

issue 寫「出現在 log 中 ≥ 3 次就進黑名單」未指定時間範圍。**終生累計 3 次**會讓偶爾連發兩則訊息的善意使用者（10 秒冷卻很容易誤觸）最終被永久封鎖，因此預設改為「**24 小時內 3 次**」，並以 vars 可調：

- `ABUSE_BLACKLIST_THRESHOLD`（預設 `"3"`）
- `ABUSE_COUNT_WINDOW_HOURS`（預設 `"24"`；設 `"0"` = 全期間累計，即嚴格按 issue 字面）

黑名單本身仍為永久（直到手動解除）：`npm run abuse:unban -- <key>` 會同時清掉該 key 的 log 舊紀錄（否則計數仍達門檻，再犯一次立即回到黑名單）。

## 基礎設施

- D1 資料庫 `askit-abuse-log` **已建立**（`d87861ce-46d5-4053-afdf-abf5c4a9f61c`，APAC）並**已套用 schema**，merge 後直接 deploy 即生效。
- binding 刻意**不**設 `remote: true`：本機 dev 寫本機 D1（與本機限流 DO 一致），不污染正式環境。本機初始化：`npm run abuse:db:init:local`。
- `ABUSE_DB` 未綁或讀寫錯誤時優雅降級（黑名單 fail-open、寫 log 靜默略過），與快取／限流相同原則。
- 成本特性：每個請求多 1 次 D1 point read；攻擊者進黑名單前最多寫 3 筆 log，進黑名單後僅剩 read，log 不會被洪水灌爆。


## 驗證

- `npm run typecheck`、`npm test` 全綠（新增 9 個測試，含 node:sqlite 跑真 schema + 真 SQL 驗證門檻／視窗／ON CONFLICT 行為）。
- `wrangler dev` 端對端煙霧測試：同一 IP 連續過長請求 → `400`（記 question_too_long）→ `429`×2（記 rate_limit，第 3 次自動進黑名單）→ `403`；黑名單 IP 對另一路徑的**首個**請求也直接 `403`；正常 IP 不受影響。測試資料已自正式 D1 清除。
- 報告腳本以 120 筆種子資料實測，HTML 渲染正常。

- 可實測/webhook和/fuse對超範圍的問題，有3秒的回應延遲

🤖 Generated with [Claude Code](https://claude.com/claude-code)