### PR TITLE
Fix CI vectorize-sync: pass API token to wrangler in GitHub Actions

### DIFF
--- a/scripts/vectorize-sync.ts
+++ b/scripts/vectorize-sync.ts
@@ -52,6 +52,7 @@ import {
   extractEmbeddings,
   type VectorizeSectionMetadata,
 } from '../src/utils/vectorize'
+import { buildWranglerEnv } from './wranglerEnv'
 
 function loadDevVarsFallback(): void {
   let raw = ''
@@ -165,21 +166,6 @@ const METADATA_CONTENT_MAX_CHARS = 2_500
 function truncateChars(s: string, max: number): string {
   const chars = Array.from(s)
   return chars.length <= max ? s : chars.slice(0, max).join('')
-}
-
-// wrangler 子行程：本機預設走 OAuth（.dev.vars 常只有 Workers AI 權限的 token，
-// 若傳給 wrangler 會蓋過 OAuth 並令 d1 / vectorize 失敗）。CI 無 OAuth session，
-// 需保留 CLOUDFLARE_API_TOKEN；亦可設 WRANGLER_USE_API_TOKEN=1 強制走 token。
-function buildWranglerEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env }
-  const useApiToken =
-    process.env.WRANGLER_USE_API_TOKEN === '1' ||
-    process.env.GITHUB_ACTIONS === 'true' ||
-    process.env.CI === 'true'
-  if (!useApiToken) {
-    delete env.CLOUDFLARE_API_TOKEN
-  }
-  return env
 }
 
 const WRANGLER_ENV = buildWranglerEnv()

--- a/scripts/vectorize-sync.ts
+++ b/scripts/vectorize-sync.ts
@@ -15,8 +15,9 @@
  *
  * 必要環境變數（嵌入走 Workers AI REST）：
  *   CLOUDFLARE_ACCOUNT_ID   目標帳號 ID
- *   CLOUDFLARE_API_TOKEN    只需 Workers AI 權限（僅供 REST 嵌入；wrangler 子行程
- *                           一律改走 OAuth 登入，避免低權限 token 蓋過 OAuth）
+ *   CLOUDFLARE_API_TOKEN    REST 嵌入必備。wrangler 子行程：CI（GITHUB_ACTIONS）或
+ *                           WRANGLER_USE_API_TOKEN=1 時沿用此 token；本機預設改走
+ *                           OAuth，避免僅 Workers AI 權限的 token 蓋過 OAuth 登入。
  *
  * 選填環境變數：
  *   D1_DATABASE             逐字稿來源 D1（預設 sayit-database）
@@ -35,6 +36,7 @@
  *   LIMIT                   本次最多處理幾筆 pending（預設不限）
  *   LOCAL=1                 對 D1 下 --local（預設 --remote）
  *   DRY_RUN=1               不嵌入 / 不 upsert / 不寫 D1，只報告
+ *   WRANGLER_USE_API_TOKEN=1  wrangler 子行程強制使用 CLOUDFLARE_API_TOKEN（CI 自動啟用）
  */
 import { execSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
@@ -165,10 +167,22 @@ function truncateChars(s: string, max: number): string {
   return chars.length <= max ? s : chars.slice(0, max).join('')
 }
 
-// wrangler 子行程一律走 OAuth 登入：CLOUDFLARE_API_TOKEN 只供 REST 嵌入使用，
-// 若留在子行程環境會蓋過 OAuth，低權限 token 將令 d1 / vectorize 指令失敗。
-const WRANGLER_ENV: NodeJS.ProcessEnv = { ...process.env }
-delete WRANGLER_ENV.CLOUDFLARE_API_TOKEN
+// wrangler 子行程：本機預設走 OAuth（.dev.vars 常只有 Workers AI 權限的 token，
+// 若傳給 wrangler 會蓋過 OAuth 並令 d1 / vectorize 失敗）。CI 無 OAuth session，
+// 需保留 CLOUDFLARE_API_TOKEN；亦可設 WRANGLER_USE_API_TOKEN=1 強制走 token。
+function buildWranglerEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  const useApiToken =
+    process.env.WRANGLER_USE_API_TOKEN === '1' ||
+    process.env.GITHUB_ACTIONS === 'true' ||
+    process.env.CI === 'true'
+  if (!useApiToken) {
+    delete env.CLOUDFLARE_API_TOKEN
+  }
+  return env
+}
+
+const WRANGLER_ENV = buildWranglerEnv()
 
 // ── D1 CLI（沿用 build-ask-index 的 execSync + --json envelope 解析）────────────
 type D1Envelope = {

--- a/scripts/wranglerEnv.ts
+++ b/scripts/wranglerEnv.ts
@@ -1,0 +1,20 @@
+/**
+ * Build env for wrangler subprocesses.
+ *
+ * Local dev often keeps a low-permission CLOUDFLARE_API_TOKEN (Workers AI only)
+ * in .dev.vars for REST embedding. Passing it to wrangler shadows OAuth and
+ * breaks d1 / vectorize. CI has no OAuth session and must keep the token.
+ */
+export function buildWranglerEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = { ...source }
+  const useApiToken =
+    source.WRANGLER_USE_API_TOKEN === '1' ||
+    source.GITHUB_ACTIONS === 'true' ||
+    source.CI === 'true'
+  if (!useApiToken) {
+    delete env.CLOUDFLARE_API_TOKEN
+  }
+  return env
+}

--- a/test/wranglerEnv.test.ts
+++ b/test/wranglerEnv.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildWranglerEnv } from '../scripts/wranglerEnv'
+
+const baseEnv: NodeJS.ProcessEnv = {
+  CLOUDFLARE_API_TOKEN: 'cf-token',
+  CLOUDFLARE_ACCOUNT_ID: 'acct-123',
+  PATH: '/usr/bin',
+}
+
+test('buildWranglerEnv strips API token locally (OAuth-first)', () => {
+  const env = buildWranglerEnv(baseEnv)
+  assert.equal(env.CLOUDFLARE_API_TOKEN, undefined)
+  assert.equal(env.CLOUDFLARE_ACCOUNT_ID, 'acct-123')
+})
+
+test('buildWranglerEnv keeps API token in GitHub Actions', () => {
+  const env = buildWranglerEnv({ ...baseEnv, GITHUB_ACTIONS: 'true' })
+  assert.equal(env.CLOUDFLARE_API_TOKEN, 'cf-token')
+})
+
+test('buildWranglerEnv keeps API token when CI=true', () => {
+  const env = buildWranglerEnv({ ...baseEnv, CI: 'true' })
+  assert.equal(env.CLOUDFLARE_API_TOKEN, 'cf-token')
+})
+
+test('buildWranglerEnv keeps API token when WRANGLER_USE_API_TOKEN=1', () => {
+  const env = buildWranglerEnv({ ...baseEnv, WRANGLER_USE_API_TOKEN: '1' })
+  assert.equal(env.CLOUDFLARE_API_TOKEN, 'cf-token')
+})
+
+test('buildWranglerEnv does not mutate the source env', () => {
+  const source = { ...baseEnv }
+  buildWranglerEnv(source)
+  assert.equal(source.CLOUDFLARE_API_TOKEN, 'cf-token')
+})


### PR DESCRIPTION
## Problem

Commit `bff4ffa` removed `CLOUDFLARE_API_TOKEN` from wrangler subprocess env in `vectorize-sync.ts` so local OAuth login is not shadowed by a low-permission Workers AI embedding token.

GitHub Actions `refresh-cag-index.yml` only provides `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` — no OAuth session — so `npm run vectorize:sync` fails on `wrangler d1 execute` / `wrangler vectorize`.

Fixes #34

## Solution

- **Local dev (default):** still strip `CLOUDFLARE_API_TOKEN` from wrangler subprocesses → OAuth
- **CI:** auto-detect `GITHUB_ACTIONS` / `CI` and keep the token for wrangler
- **Override:** `WRANGLER_USE_API_TOKEN=1` forces token auth anywhere

No workflow YAML changes needed — GitHub Actions sets `GITHUB_ACTIONS=true` automatically.