### PR TITLE
介面輸入字數限制與過長警告 + /au 與 /cag 檢索優雅降級優化 + 黑名單記憶體快取

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,5 @@
 (function () {
-  const { createApp, ref, computed, h } = Vue
+  const { createApp, ref, computed, h, watch } = Vue
 
   const COOLDOWN_SECONDS = 3
   const DOC_LANG = (typeof document !== 'undefined' && document.documentElement)
@@ -29,6 +29,7 @@
       networkError: '連線發生錯誤，請稍後再試。',
       download: '下載 Markdown',
       downloadFallbackName: '回答',
+      tooLong: '您的問題字數過長，請縮短問題的長度，謝謝！',
       sourcesHeading: '出處',
       samples: [
         '什麼是仁工智慧？',
@@ -59,6 +60,7 @@
       networkError: 'Connection error. Please try again later.',
       download: 'Download Markdown',
       downloadFallbackName: 'answer',
+      tooLong: 'Your question is too long — please shorten it and try again. Thank you!',
       sourcesHeading: 'Sources',
       samples: [
         'What is Plurality?',
@@ -213,6 +215,18 @@
       const cooldown = ref(0)
       const capacityFull = ref(false)
       let cooldownTimer = null
+
+      watch(question, (newVal, oldVal) => {
+        const codePoints = [...newVal]
+        if (codePoints.length > 100) {
+          question.value = codePoints.slice(0, 100).join('')
+          error.value = T.tooLong
+        } else if (error.value === T.tooLong && [...oldVal].length > 100) {
+          // Truncation trigger, do not clear error
+        } else if (error.value === T.tooLong) {
+          error.value = ''
+        }
+      })
 
       // 提問前先打自己的 /capacity（issue #43）：額度滿時擋下發問並提示。
       // 查詢失敗就維持可發問，別讓狀態查詢本身擋住使用者。
@@ -386,7 +400,7 @@
               }, sample),
             ))
             : null,
-          answered.value
+          (answered.value || error.value)
             ? h('div', { class: 'answer' }, [
               !bodyHtml.value && !error.value && loading.value
                 ? h('p', { class: 'placeholder' }, T.searching)

--- a/src/utils/abuse.ts
+++ b/src/utils/abuse.ts
@@ -47,6 +47,9 @@ export function truncateQuestionForLog(question: string): string {
   if (chars.length <= MAX_LOGGED_QUESTION_CHARS) return chars.join('')
   return `${chars.slice(0, MAX_LOGGED_QUESTION_CHARS).join('')}…`
 }
+const blacklistCache = new Map<string, { value: boolean; expires: number }>()
+const CACHE_TTL_MS = 60 * 1000 // 1 minute
+
 
 // 黑名單比對。每個請求一次 point read；查詢失敗時 fail-open（視為未在黑名單），
 // 寧可放過也不誤擋。
@@ -55,12 +58,19 @@ export async function isBlacklisted(
   key: string,
 ): Promise<boolean> {
   if (!db) return false
+  const now = Date.now()
+  const cached = blacklistCache.get(key)
+  if (cached && cached.expires > now) {
+    return cached.value
+  }
   try {
     const row = await db
       .prepare('SELECT key FROM blacklist WHERE key = ?1')
       .bind(key)
       .first()
-    return row !== null
+    const isBanned = row !== null
+    blacklistCache.set(key, { value: isBanned, expires: now + CACHE_TTL_MS })
+    return isBanned
   } catch (e) {
     console.error('黑名單查詢失敗，視為未在黑名單:', e)
     return false
@@ -76,6 +86,7 @@ export async function recordAbuse(
   options: AbuseThresholdOptions,
 ): Promise<void> {
   if (!db) return
+  blacklistCache.delete(entry.key)
   const now = Date.now()
   const windowStart = options.windowMs > 0 ? now - options.windowMs : 0
   try {
@@ -106,6 +117,7 @@ export async function recordAbuse(
         )
         .bind(entry.key, entry.kind, now, windowStart, options.threshold),
     ])
+    blacklistCache.delete(entry.key)
   } catch (e) {
     console.error('異常請求 log 寫入失敗，略過:', e)
   }

--- a/src/utils/cag.ts
+++ b/src/utils/cag.ts
@@ -606,7 +606,7 @@ async function searchSectionsByContent(
     .replace(/^[^\p{L}\p{N}]+/u, '')
     .replace(/[^\p{L}\p{N}]+$/u, '')
   const variants = [cleaned, withoutQuestionWords]
-    .filter((v, i, arr) => v.length >= 2 && arr.indexOf(v) === i)
+    .filter((v, i, arr) => v.length >= 2 && v.length <= 15 && arr.indexOf(v) === i)
   if (variants.length === 0) return []
 
   const placeholders = variants.map(() => 'sc.section_content LIKE ?').join(' OR ')

--- a/test/appStrings.test.ts
+++ b/test/appStrings.test.ts
@@ -15,6 +15,8 @@ test('app.js zh-Hant and en string tables stay in parity', async () => {
   assert.equal(String(zh.heading), '鳳問')
   assert.match(String(zh.searching), /整理回答中/)
   assert.match(String(en.searching), /composing an answer/)
+  assert.match(String(zh.tooLong), /問題字數過長/)
+  assert.match(String(en.tooLong), /question is too long/)
 })
 
 test('app.js exposes a capacity-full notice in both languages (issue #43)', async () => {

--- a/test/cag.test.ts
+++ b/test/cag.test.ts
@@ -1831,7 +1831,7 @@ test('resolveCagSources treats a failing D1 sayitDb as empty (issue #46 graceful
   const noopAi = { run: async () => { throw new Error('should not be called') } } as unknown as Parameters<typeof resolveCagSources>[0]
 
   try {
-    const sources = await resolveCagSources(noopAi, '關懷六力的憑據是什麼？，在社會上不會受傷嗎', {
+    const sources = await resolveCagSources(noopAi, '關懷六力', {
       topK: 4,
       archiveBaseUrl: 'https://archive.tw',
       retriever: 'archive',


### PR DESCRIPTION
Closes #46.

## 內容

延續上一動，徹底解決 `/au` 的崩潰並優化使用者體驗與效能：

### 1. 介面輸入字數限制與過長警告
- `public/app.js` 加入 `watch(question)` 監聽，長度超過 100 碼點時在前端自動截斷，並將 `error.value` 設為 `T.tooLong` 進行即時提示。
- 解決 feedback loop：過濾掉因為 truncation 自身引發的 newVal/oldVal 反饋迴路，當使用者主動刪減字元至 <= 100 時才將錯誤清除。
- 調整渲染條件：`answered.value || error.value` 時即渲染 `.answer`，否則未提問前的驗證錯誤會被隱藏。
- `test/appStrings.test.ts` 加入 `tooLong` 的 regex 斷言。

### 2. /au 與 /cag 檢索優雅降級優化 (LIKE 限制)
- **分析**：D1 拋出 `LIKE or GLOB pattern too complex: SQLITE_ERROR` 的真正原因是 SQLite 對於包含長 CJK 複雜萬用字元（例如大於 15-20 字的句子）進行全表 LIKE 比對時觸發了內部遞迴／複雜度限制。
- **修法**：在 `searchSectionsByContent` 限制 `v.length <= 15`。超過 15 字的整句在 D1 fallback 中不再發起全表 LIKE 掃描（這種長句本來就極難被 substring 匹配，且極耗 read units）。這在根源上消除了 LIKE too complex 錯誤。
- **測試**：將 `test/cag.test.ts` 中 fail-open 回歸測試的問句改為 `'關懷六力'`（4字，<= 15），確保它仍能打入 D1 進而觸發 mock throw 覆蓋。

### 3. 黑名單記憶體快取 (減輕 D1 負載)
- 在 `src/utils/abuse.ts` 內建立 `blacklistCache` (1分鐘 TTL)，對 `isBlacklisted` 結果進行 container-level 記憶體快取，免除每個請求都打 D1 的讀取開銷。
- `recordAbuse` 成功寫入時主動 eviction `blacklistCache.delete(entry.key)`，確保新封鎖可即時生效。

## 驗收
- ✅ `npm run typecheck`
- ✅ `npm test` — 176/176 pass
- ✅ 本機 `wrangler dev --local` + Chromium E2E 自動化測試：
  - 輸入 105 字元：欄位截斷至 100，紅字警告 `'您的問題字數過長，請縮短問題的長度，謝謝！'` 即時出現。
  - 清空或退格：警告消失。
  - 輸入 `'關懷六力的憑據是什麼？，在社會上不會受傷嗎'`（> 15 字）：直接跳過 D1 查詢，回傳 404，不拋出任何異常。