### PR TITLE
黑名單豁免共用基礎設施網段，修近端預覽首頁 403（#49, #50）

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ Also available as a LINE bot.
   per key, then a per-key Durable Object cooldown), a global generation
   budget (30/min, 1000/day), 30 s CPU cap, strict CSP and security headers.
   Rate-limit hits and over-long questions are logged to a D1 abuse log, and
-  repeat offenders are auto-blacklisted (default: 3 events in 24 h → `403`);
-  unbind `ABUSE_DB` and it degrades gracefully (no log, empty blacklist).
+  repeat offenders are auto-blacklisted (default: 3 events in 24 h → `403`).
+  Shared-infrastructure ranges (Cloudflare/WARP egress, loopback, private
+  networks) are logged but never blacklisted, so a single shared egress IP
+  can't get innocent users — or a developer on WARP — locked out (issues
+  #49/#50; real-time rate limiting and the global budget still apply).
+  Unbind `ABUSE_DB` and it degrades gracefully (no log, empty blacklist).
   LINE events with no per-source identity (a 1:1 user who didn't share a
   `userId`, so they can't be rate-limited or blacklisted) are acked and
   dropped; groups/rooms keep their `groupId`/`roomId` and respond normally.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -42,7 +42,10 @@
   per-key Durable Object 冷卻）、全域生成預算（每分鐘 30 次、每日 1000
   次）、30 秒 CPU 上限、嚴格 CSP 與安全標頭。觸發限流或問題過長會寫入
   D1 異常請求 log，累犯自動進黑名單（預設 24 小時內 3 次 → `403`）；
-  未綁 `ABUSE_DB` 時優雅降級（不寫 log、黑名單視為空）。LINE 事件若無可
+  共用基礎設施網段（Cloudflare／WARP 出口、loopback、私有網段）只記錄、
+  不進黑名單，避免誤封同出口的無辜使用者或走 WARP 的開發者自己（issue
+  #49／#50；即時限流與全域預算仍照常生效）。未綁 `ABUSE_DB` 時優雅降級
+  （不寫 log、黑名單視為空）。LINE 事件若無可
   識別的個別身分（1:1 個人未提供 `userId`，無從限流、也無從加黑名單）一律
   ack 後丟棄；群組／房間有 `groupId`／`roomId` 可識別，正常回應。
 - **品質** — 離線 eval harness（`npm run eval:cag`、

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   resolveAudreySkillModel,
 } from './utils/audreySkill'
 import { isAuthorizedFromHeader } from './utils/auth'
+import { isBlacklistExemptIp } from './utils/trustedRanges'
 import {
   buildCacheKey,
   getCachedResponse,
@@ -629,8 +630,13 @@ function reportAbuse(
 ): void {
   const { key, ...rest } = entry
   if (!key) return
+  // 共用基礎設施網段（Cloudflare／WARP 出口、loopback、私有網段）只記錄不進黑名單：
+  // 永久封鎖會誤傷同出口的無辜使用者（issue #49/#50）。即時限流與全域預算不受影響。
+  const skipBlacklist = rest.ip ? isBlacklistExemptIp(rest.ip) : false
   c.executionCtx.waitUntil(
-    recordAbuse(c.env.ABUSE_DB, { key, ...rest }, resolveAbuseOptions(c.env)),
+    recordAbuse(c.env.ABUSE_DB, { key, ...rest }, resolveAbuseOptions(c.env), {
+      skipBlacklist,
+    }),
   )
 }
 
@@ -648,6 +654,10 @@ async function checkHttpBlacklist(
   const ip = c.req.header('cf-connecting-ip')
   const key = ip ? ipRateLimitKeyFromIp(ip) : null
   if (!key) return { ip, key, blocked: false }
+  // 共用基礎設施網段（Cloudflare／WARP 出口、loopback、私有網段）豁免永久黑名單比對：
+  // 這些位址一個背後是海量使用者，封鎖會誤傷無辜、也鎖住走 WARP 的開發者
+  // （npm run preview 首頁 403，issue #49/#50）。即時限流與全域預算仍照常生效。
+  if (ip && isBlacklistExemptIp(ip)) return { ip, key, blocked: false }
   return { ip, key, blocked: await isBlacklisted(c.env.ABUSE_DB, key) }
 }
 

--- a/src/utils/abuse.ts
+++ b/src/utils/abuse.ts
@@ -77,34 +77,52 @@ export async function isBlacklisted(
   }
 }
 
+export type RecordAbuseExtra = {
+  /**
+   * 略過自動黑名單寫入（仍寫 abuse_log 供分析）。共用基礎設施網段
+   * （Cloudflare／WARP 出口、loopback、私有網段）設 true：這些 IP 一個背後是
+   * 海量使用者、永久封鎖會誤傷無辜，故只記錄不封鎖（判斷見 src/utils/trustedRanges.ts；
+   * 套用於 src/index.ts 的 reportAbuse）。
+   */
+  skipBlacklist?: boolean
+}
+
 // 寫入一筆異常紀錄，並在同一個 batch 交易內檢查門檻、自動寫入黑名單。
 // 第二句 INSERT…SELECT 的計數包含第一句剛插入的那筆；ON CONFLICT DO NOTHING
 // 讓已在黑名單的 key 重跑安全（理論上不會發生：黑名單成員在更上游就被擋下）。
+// skipBlacklist=true 時只寫 abuse_log、不寫黑名單（共用網段豁免，見 RecordAbuseExtra）。
 export async function recordAbuse(
   db: D1Database | undefined,
   entry: AbuseLogEntry,
   options: AbuseThresholdOptions,
+  extra: RecordAbuseExtra = {},
 ): Promise<void> {
   if (!db) return
   blacklistCache.delete(entry.key)
   const now = Date.now()
   const windowStart = options.windowMs > 0 ? now - options.windowMs : 0
   try {
+    const logStatement = db
+      .prepare(
+        'INSERT INTO abuse_log (key, kind, path, question, ip, line_id, created_at) ' +
+          'VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)',
+      )
+      .bind(
+        entry.key,
+        entry.kind,
+        entry.path,
+        truncateQuestionForLog(entry.question),
+        entry.ip ?? null,
+        entry.lineId ?? null,
+        now,
+      )
+    if (extra.skipBlacklist) {
+      // 共用基礎設施網段：只留 log（供分析「哪個網段在製造異常」），不進黑名單。
+      await logStatement.run()
+      return
+    }
     await db.batch([
-      db
-        .prepare(
-          'INSERT INTO abuse_log (key, kind, path, question, ip, line_id, created_at) ' +
-            'VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)',
-        )
-        .bind(
-          entry.key,
-          entry.kind,
-          entry.path,
-          truncateQuestionForLog(entry.question),
-          entry.ip ?? null,
-          entry.lineId ?? null,
-          now,
-        ),
+      logStatement,
       // 子查詢先算出視窗內次數，外層 WHERE 過門檻才插入。
       // （SQLite 的 upsert 文法要求 INSERT…SELECT 帶 WHERE 子句以消除與 join 的歧義。）
       db

--- a/src/utils/trustedRanges.ts
+++ b/src/utils/trustedRanges.ts
@@ -1,0 +1,175 @@
+// Issue #49 / #50 — 共用基礎設施網段的「永久黑名單」豁免。
+//
+// 自動黑名單（src/utils/abuse.ts）以來源 IP 為 key 永久封鎖累犯。問題在於：
+// Cloudflare WARP 的消費端出口、Cloudflare 邊緣、loopback／私有網段這些位址，
+// 「一個 IP 背後是成千上萬個使用者」且會輪換出口。對它們做永久封鎖會：
+//   1. 誤傷一整票共用同一出口的無辜使用者；
+//   2. 把走 WARP 的開發者自己鎖在門外——`npm run preview`（wrangler dev --remote）
+//      時 cf-connecting-ip 就是 WARP 出口（如 104.28.198.3），首頁的 /capacity、
+//      /au 請求被 403（issue #49）；
+//   3. 對會輪換出口的攻擊者其實也擋不住。
+//
+// 因此這些網段一律豁免「永久黑名單」的「寫入」與「比對」兩端。
+// 重點：豁免的「只有」黑名單這一層——每 IP 即時限流（DO）與全域生成預算
+// 仍照常生效，所以共用出口依然被即時節流，不會給攻擊者新的可乘之機。
+
+// Cloudflare 對外 announce 的位址空間（whois: CLOUDFLARENET）。
+//
+// 注意 104.16.0.0/12：官方「CDN 邊緣」清單把這塊切成 104.16.0.0/13 +
+// 104.24.0.0/14（只到 104.27.x）。但 WARP 消費端出口（issue #50 的實際肇因
+// 104.28.198.3）落在 104.28.x，在那份較窄的 ingress 清單之外、卻仍在 Cloudflare
+// 對外 announce 的完整 /12（104.16.x–104.31.x）內。我們要豁免的是「共用出口」，
+// 所以採用完整 /12，把 WARP 出口一併涵蓋。其餘沿用官方公布清單。
+const CLOUDFLARE_V4 = [
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/12', // 完整 /12，含 WARP 出口 104.28.x（見上）
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+] as const
+
+const CLOUDFLARE_V6 = [
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+] as const
+
+// loopback／私有／link-local。production 的 cf-connecting-ip 由 Cloudflare 邊緣
+// 填入真實客戶端 IP，永遠不會是這些位址；因此豁免它們「只」影響本機 dev
+// （wrangler dev 可能把 cf-connecting-ip 設成 127.0.0.1），對 production 零風險，
+// 但能避免不走 WARP 的開發者也把自己鎖住。
+const PRIVATE_V4 = [
+  '127.0.0.0/8',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '169.254.0.0/16',
+] as const
+
+const PRIVATE_V6 = ['::1/128', 'fc00::/7', 'fe80::/10'] as const
+
+type Cidr4 = { base: number; bits: number }
+type Cidr6 = { base: bigint; bits: number }
+
+function parseIpv4(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let value = 0
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n > 255) return null
+    value = value * 256 + n
+  }
+  return value >>> 0
+}
+
+function parseIpv6(input: string): bigint | null {
+  let ip = input
+  const zone = ip.indexOf('%')
+  if (zone !== -1) ip = ip.slice(0, zone)
+
+  // 內嵌 IPv4（如 ::ffff:1.2.3.4）：把尾端 IPv4 轉成兩個 16-bit 群組。
+  if (ip.includes('.')) {
+    const lastColon = ip.lastIndexOf(':')
+    if (lastColon === -1) return null
+    const v4 = parseIpv4(ip.slice(lastColon + 1))
+    if (v4 === null) return null
+    const hi = ((v4 >>> 16) & 0xffff).toString(16)
+    const lo = (v4 & 0xffff).toString(16)
+    ip = `${ip.slice(0, lastColon + 1)}${hi}:${lo}`
+  }
+
+  const halves = ip.split('::')
+  if (halves.length > 2) return null
+  const toGroups = (s: string): string[] => (s === '' ? [] : s.split(':'))
+  const head = toGroups(halves[0])
+  const tail = halves.length === 2 ? toGroups(halves[1]) : null
+
+  let groups: string[]
+  if (tail === null) {
+    groups = head
+  } else {
+    const missing = 8 - head.length - tail.length
+    if (missing < 1) return null
+    groups = [...head, ...Array.from({ length: missing }, () => '0'), ...tail]
+  }
+  if (groups.length !== 8) return null
+
+  let value = 0n
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null
+    value = (value << 16n) + BigInt(Number.parseInt(group, 16))
+  }
+  return value
+}
+
+function parseCidr4(cidr: string): Cidr4 {
+  const [addr, bitsStr] = cidr.split('/')
+  const base = parseIpv4(addr)
+  if (base === null) throw new Error(`不合法的 IPv4 CIDR：${cidr}`)
+  return { base, bits: Number(bitsStr) }
+}
+
+function parseCidr6(cidr: string): Cidr6 {
+  const [addr, bitsStr] = cidr.split('/')
+  const base = parseIpv6(addr)
+  if (base === null) throw new Error(`不合法的 IPv6 CIDR：${cidr}`)
+  return { base, bits: Number(bitsStr) }
+}
+
+function inCidr4(ip: number, cidr: Cidr4): boolean {
+  if (cidr.bits === 0) return true
+  // bits 介於 1..32：左移 (32-bits) 後 >>> 0 取無號 32-bit 遮罩。
+  const mask = (0xffffffff << (32 - cidr.bits)) >>> 0
+  return ((ip & mask) >>> 0) === ((cidr.base & mask) >>> 0)
+}
+
+function inCidr6(ip: bigint, cidr: Cidr6): boolean {
+  if (cidr.bits === 0) return true
+  const shift = BigInt(128 - cidr.bits)
+  return ip >> shift === cidr.base >> shift
+}
+
+const CLOUDFLARE_V4_CIDRS = CLOUDFLARE_V4.map(parseCidr4)
+const PRIVATE_V4_CIDRS = PRIVATE_V4.map(parseCidr4)
+const EXEMPT_V4_CIDRS = [...CLOUDFLARE_V4_CIDRS, ...PRIVATE_V4_CIDRS]
+
+const CLOUDFLARE_V6_CIDRS = CLOUDFLARE_V6.map(parseCidr6)
+const PRIVATE_V6_CIDRS = PRIVATE_V6.map(parseCidr6)
+const EXEMPT_V6_CIDRS = [...CLOUDFLARE_V6_CIDRS, ...PRIVATE_V6_CIDRS]
+
+// 來源 IP 是否屬於「永久黑名單豁免」的共用基礎設施網段
+// （Cloudflare／WARP 出口、loopback、私有網段）。無法解析的 IP 視為不豁免
+// （fail-safe：寧可照常比對黑名單，也不誤放）。
+export function isBlacklistExemptIp(ip: string): boolean {
+  const normalized = ip.trim().toLowerCase()
+  if (!normalized) return false
+  if (normalized.includes(':')) {
+    const value = parseIpv6(normalized)
+    if (value === null) return false
+    // IPv4-mapped IPv6（::ffff:a.b.c.d，即 ::ffff:0:0/96）：以內嵌的 IPv4 判定，
+    // 否則同一個 IPv4 換成 mapped 寫法就會繞過豁免。
+    if (value >> 32n === 0xffffn) {
+      const v4 = Number(value & 0xffffffffn)
+      return EXEMPT_V4_CIDRS.some((cidr) => inCidr4(v4, cidr))
+    }
+    return EXEMPT_V6_CIDRS.some((cidr) => inCidr6(value, cidr))
+  }
+  const value = parseIpv4(normalized)
+  if (value === null) return false
+  return EXEMPT_V4_CIDRS.some((cidr) => inCidr4(value, cidr))
+}

--- a/test/abuse.test.ts
+++ b/test/abuse.test.ts
@@ -143,6 +143,19 @@ test('視窗外的舊紀錄不列入計數', async () => {
   assert.equal(await isBlacklisted(d1, 'ip:1.2.3.4'), true)
 })
 
+test('skipBlacklist：共用網段只寫 log、永不進黑名單（即使達門檻）', async () => {
+  const { db, d1 } = createSqliteBackedD1()
+  const cf = entry({ key: 'ip:104.28.198.3', ip: '104.28.198.3' })
+  for (let i = 0; i < 5; i++) {
+    await recordAbuse(d1, cf, OPTIONS, { skipBlacklist: true })
+  }
+  const logs = db.prepare('SELECT * FROM abuse_log').all() as Record<string, unknown>[]
+  assert.equal(logs.length, 5) // log 照常累積，供分析
+  const bl = db.prepare('SELECT * FROM blacklist').all() as Record<string, unknown>[]
+  assert.equal(bl.length, 0) // 但永不進黑名單
+  assert.equal(await isBlacklisted(d1, 'ip:104.28.198.3'), false)
+})
+
 test('超長問題寫入 log 前會截斷', async () => {
   const { db, d1 } = createSqliteBackedD1()
   await recordAbuse(d1, entry({ question: 'x'.repeat(10_000) }), OPTIONS)

--- a/test/trustedRanges.test.ts
+++ b/test/trustedRanges.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isBlacklistExemptIp } from '../src/utils/trustedRanges'
+
+test('Cloudflare WARP 出口（issue #50 實際肇因）落在完整 /12 內，豁免', () => {
+  // 104.28.198.3 在 Cloudflare 對外 announce 的 104.16.0.0/12，但「不在」官方
+  // CDN ingress 清單（104.16/13 + 104.24/14 只到 104.27.x）。必須被豁免。
+  assert.equal(isBlacklistExemptIp('104.28.198.3'), true)
+  assert.equal(isBlacklistExemptIp('104.28.198.10'), true)
+})
+
+test('Cloudflare 公布的 CDN 邊緣網段也豁免', () => {
+  assert.equal(isBlacklistExemptIp('162.158.0.1'), true) // 162.158.0.0/15
+  assert.equal(isBlacklistExemptIp('172.64.0.1'), true) // 172.64.0.0/13
+  assert.equal(isBlacklistExemptIp('131.0.72.1'), true) // 131.0.72.0/22
+})
+
+test('Cloudflare IPv6 網段豁免（含大小寫與 :: 壓縮）', () => {
+  assert.equal(isBlacklistExemptIp('2606:4700::1'), true)
+  assert.equal(isBlacklistExemptIp('2400:CB00:0:0:0:0:0:1'), true)
+  assert.equal(isBlacklistExemptIp('2a06:98c0::abcd'), true) // /29
+})
+
+test('loopback 與私有網段豁免（修開發者自鎖，零 production 風險）', () => {
+  assert.equal(isBlacklistExemptIp('127.0.0.1'), true)
+  assert.equal(isBlacklistExemptIp('10.1.2.3'), true)
+  assert.equal(isBlacklistExemptIp('172.16.5.5'), true)
+  assert.equal(isBlacklistExemptIp('192.168.1.100'), true)
+  assert.equal(isBlacklistExemptIp('169.254.1.1'), true)
+  assert.equal(isBlacklistExemptIp('::1'), true)
+  assert.equal(isBlacklistExemptIp('fe80::1'), true)
+  assert.equal(isBlacklistExemptIp('fc00::1234'), true)
+})
+
+test('一般公網 IP 不豁免（仍照常比對黑名單）', () => {
+  assert.equal(isBlacklistExemptIp('8.8.8.8'), false)
+  assert.equal(isBlacklistExemptIp('1.1.1.1'), false) // 1.1.1.1 是 DNS，非 announce 的共用出口
+  assert.equal(isBlacklistExemptIp('203.0.113.7'), false)
+  assert.equal(isBlacklistExemptIp('172.32.0.1'), false) // 緊鄰 172.16/12 之外
+  assert.equal(isBlacklistExemptIp('104.32.0.1'), false) // 緊鄰 104.16/12 之外
+  assert.equal(isBlacklistExemptIp('2001:4860:4860::8888'), false) // Google IPv6
+})
+
+test('邊界：/12 與 /13+/14 的接縫處', () => {
+  assert.equal(isBlacklistExemptIp('104.16.0.0'), true) // /12 起點
+  assert.equal(isBlacklistExemptIp('104.31.255.255'), true) // /12 終點
+  assert.equal(isBlacklistExemptIp('104.15.255.255'), false) // /12 前一個
+  assert.equal(isBlacklistExemptIp('104.32.0.0'), false) // /12 後一個
+})
+
+test('無法解析的輸入 fail-safe 為「不豁免」', () => {
+  assert.equal(isBlacklistExemptIp(''), false)
+  assert.equal(isBlacklistExemptIp('  '), false)
+  assert.equal(isBlacklistExemptIp('not-an-ip'), false)
+  assert.equal(isBlacklistExemptIp('999.1.1.1'), false)
+  assert.equal(isBlacklistExemptIp('1.2.3'), false)
+})
+
+test('內嵌 IPv4 的 IPv6（IPv4-mapped）以其 IPv4 判定', () => {
+  assert.equal(isBlacklistExemptIp('::ffff:104.28.198.3'), true)
+  assert.equal(isBlacklistExemptIp('::ffff:127.0.0.1'), true)
+  assert.equal(isBlacklistExemptIp('::ffff:8.8.8.8'), false) // 內嵌一般公網 IPv4
+})


### PR DESCRIPTION
# 與Claude Opus 4.8 協作

## 背景

自動黑名單（`src/utils/abuse.ts`）以來源 IP 為 key 永久封鎖累犯。診斷 issue #50 發現：被封的 `104.28.198.3`（whois: **CLOUDFLARENET**）是 **Cloudflare WARP 消費端出口**——落在 Cloudflare 對外 announce 的完整 `104.16.0.0/12`，但**不在**官方 CDN ingress 清單（`104.16/13`+`104.24/14` 只到 104.27.x）。

這類「一個 IP 背後是海量使用者」且會輪換出口的共用位址，做永久封鎖會：
1. **誤傷**同出口的無辜使用者；
2. 把走 WARP 的**開發者自己鎖住**——`npm run preview`（`wrangler dev --remote`）時 `cf-connecting-ip` 就是 WARP 出口，首頁的 `/capacity`、`/au` 請求被 `403`（這正是 **issue #49** 的近端預覽首頁 403）；
3. 對會輪換出口的攻擊者其實也**擋不住**。

`#49` 與 `#50` 是同一個根因，本 PR 一併修復。

## 變更

- **新增 `src/utils/trustedRanges.ts`**：`isBlacklistExemptIp(ip)` 以 IPv4/IPv6 CIDR 比對
  - Cloudflare announce 網段（含 WARP 出口的**完整 `104.16.0.0/12`**，其餘沿用官方公布清單 + IPv6）
  - loopback / 私有 / link-local（production 的 `cf-connecting-ip` 不會是這些，故只影響本機 dev，零 production 風險）
  - 內嵌 IPv4 的 IPv6（IPv4-mapped）以其 IPv4 判定；無法解析的 IP **fail-safe 為不豁免**。
- **`checkHttpBlacklist`**：豁免 IP 直接視為未命中（不查 D1）。
- **`reportAbuse` → `recordAbuse`**：豁免 IP 帶 `skipBlacklist`——仍寫 `abuse_log`（供分析「哪個網段在製造異常」），但**不寫黑名單**。

## 安全權衡（為何這不是給攻擊者開後門）

**只豁免「永久黑名單」這一層**。每個答案端點的閘門順序是：

```
1. isTrustedCaller   → Bearer token 全略過
2. checkHttpBlacklist→ 403  ← 本 PR 對共用網段豁免的就是這層
3. isIpRateLimited   → 429  ← 每 IP 即時限流（DO），照常生效
4. isQuestionTooLong → 400
5. checkGlobalBudget → 429  ← 全域生成預算，照常生效
```

共用出口仍被第 3、5 層即時節流，拿不到無限生成。而且維持現狀（照封 WARP IP）對「會輪換出口的攻擊者」本來就擋不住，卻會誤傷無辜——這個交換是划算的。LINE 路徑用 `line:` key，不受影響。

> 附帶（**本 PR 不處理**）：第 3 層「每 IP 限流」對 WARP 出口是整池一起算，屬「無法用 IP 區分 WARP 使用者」的根本限制，可另開議題。

## 測試

- `test/trustedRanges.test.ts`：`104.28.198.3`/`.10` 豁免、CDN 邊緣與 IPv6 網段、loopback/私有、一般公網不豁免、`/12` 接縫邊界、fail-safe、IPv4-mapped。
- `test/abuse.test.ts`：`recordAbuse` 帶 `skipBlacklist` 時只寫 log、即使達門檻也永不進黑名單。
- `npm test` 200 passed、`npm run typecheck` 通過。

Closes #49
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)