### PR TITLE
首頁 markdown ## / ### 轉成 <h2>/<h3> 顯示 (#52)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -152,6 +152,15 @@
     const hrefByIndex = new Map(sources.map((s) => [s.index, s.href]))
 
     let html = escapeHtml(body)
+    // 將行首的 Markdown 標題（# ~ ######）轉成對應的 <h1>~<h6>，
+    // 只影響畫面顯示；下載／複製用的是未轉換的原始 Markdown。
+    html = html.replace(
+      /^(#{1,6})[ \t]+([^\n]+?)[ \t]*(?:\n|$)/gm,
+      (_m, hashes, text) => {
+        const level = hashes.length
+        return '<h' + level + '>' + text + '</h' + level + '>'
+      },
+    )
     html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>')
     html = html.replace(

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -220,6 +220,28 @@ export function renderHomePage(lang: PageLang = 'zh-Hant'): string {
     }
     .answer .placeholder { color: var(--muted); }
     .answer .body { white-space: pre-wrap; }
+    .answer .body h1,
+    .answer .body h2,
+    .answer .body h3,
+    .answer .body h4,
+    .answer .body h5,
+    .answer .body h6 {
+      font-weight: 700;
+      line-height: 1.3;
+      margin: 1.1em 0 0.4em;
+    }
+    .answer .body h1:first-child,
+    .answer .body h2:first-child,
+    .answer .body h3:first-child,
+    .answer .body h4:first-child,
+    .answer .body h5:first-child,
+    .answer .body h6:first-child { margin-top: 0; }
+    .answer .body h1 { font-size: 1.3rem; }
+    .answer .body h2 { font-size: 1.15rem; }
+    .answer .body h3 { font-size: 1.02rem; }
+    .answer .body h4,
+    .answer .body h5,
+    .answer .body h6 { font-size: 0.95rem; }
     .answer .error { color: #b3261e; }
     sup.cite a {
       font-size: 0.72em;

--- a/test/cag.test.ts
+++ b/test/cag.test.ts
@@ -452,6 +452,34 @@ test('homepage parser rejects non-http citation URLs and relative URLs', async (
   assert.doesNotMatch(parsed.html, /href="\/relative\/path"/i)
 })
 
+test('homepage parser converts markdown headings to <h2>/<h3> for display', async () => {
+  const { parseAnswer } = await loadAppTestHooks()
+  const parsed = parseAnswer([
+    '## 主標題',
+    '',
+    '一些內文 **重點**。',
+    '',
+    '### 子標題',
+    '更多內文。',
+  ].join('\n'))
+
+  assert.match(parsed.html, /<h2>主標題<\/h2>/)
+  assert.match(parsed.html, /<h3>子標題<\/h3>/)
+  // 標題行不應留下原始的 ## / ### 標記
+  assert.doesNotMatch(parsed.html, /(^|\n)#{1,6}\s/)
+  // 內文仍然保留行內格式
+  assert.match(parsed.html, /<strong>重點<\/strong>/)
+})
+
+test('homepage parser leaves non-heading hashes untouched', async () => {
+  const { parseAnswer } = await loadAppTestHooks()
+  const parsed = parseAnswer('#沒有空白不是標題\n價格 #1 與 #2')
+
+  assert.doesNotMatch(parsed.html, /<h1>/)
+  assert.match(parsed.html, /#沒有空白不是標題/)
+  assert.match(parsed.html, /價格 #1 與 #2/)
+})
+
 test('homepage renders out-of-scope errors as sanitized html with archive.tw link', async () => {
   const { formatErrorHtml } = await loadAppTestHooks()
   const html = formatErrorHtml(NOT_FOUND_REPLY_HTML)


### PR DESCRIPTION
## 問題

首頁回答中的 Markdown 標題 `##` / `###` 會直接以純文字顯示，沒有變成標題。（議題 #52）

## 修法

只調整「顯示用的 HTML」，**下載／複製仍使用未轉換的原始 Markdown**（本來就讀 `raw.value`，不受影響）。

- **`public/app.js`** — 在 `parseAnswer()` 的 `escapeHtml(body)` 之後、行內格式轉換之前，新增行首標題轉換：`#`~`######` → `<h1>`~`<h6>`（`##`→`<h2>`、`###`→`<h3>`）。
  - 需有空白才算標題，所以 `#1`、`#沒空白` 不會被誤判。
  - 消化標題行尾的換行，避免和 `white-space: pre-wrap` 疊出多餘空行；標題內的粗體／連結仍正常處理。
  - `<h2>`/`<h3>` 不在 `BLOCKED_ELEMENT_SELECTOR`，會通過既有的 `sanitizeHtml()`。
- **`src/pages/home.ts`** — 為 `.answer .body` 內的 `h1`~`h6` 加上字級與間距樣式（首個標題去掉上邊距），讓標題在 pre-wrap 答案卡裡有合理視覺層級。
- **`test/cag.test.ts`** — 新增兩個測試：標題正確轉成 `<h2>/<h3>` 且行內格式仍在；非標題的 `#` 不被轉換。

## 驗證

- `npm test` → 193/193 通過（含 2 個新測試）
- `npm run typecheck` → 通過

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)