### PR TITLE
修理 bigram index CI：拆分遠端 D1 匯入避免單一 session 逾時

### DIFF
--- a/scripts/build-bigram-index-split.ts
+++ b/scripts/build-bigram-index-split.ts
@@ -1,0 +1,28 @@
+/**
+ * 把「DELETE header + 一串 INSERT 語句」切成多個遠端匯入分檔，每檔的 UTF-8 位元組
+ * 不超過 maxBytes（單一語句本身就超標時，例外地獨佔一檔——絕不產生空檔或死迴圈）。
+ *
+ * 純函式、無副作用，方便被 build-bigram-index.ts 與單元測試共用。
+ * 行為與原本內聯切檔迴圈逐位元組等價。
+ */
+export function splitSqlIntoImportFiles(
+  header: string,
+  statements: string[],
+  maxBytes: number,
+): string[] {
+  const files: string[] = []
+  let body = header
+  for (const stmt of statements) {
+    const bodyBytes = Buffer.byteLength(body, 'utf-8')
+    const stmtBytes = Buffer.byteLength(stmt, 'utf-8')
+    // 目前分檔非空、且再加一條會超標，就先收檔、開新檔（新檔不再帶 header）。
+    // 守住 body.length > 0：避免單一語句本身就大於上限時陷入空檔死迴圈。
+    if (body.length > 0 && bodyBytes + stmtBytes > maxBytes) {
+      files.push(body)
+      body = ''
+    }
+    body += stmt
+  }
+  if (body.length > 0) files.push(body)
+  return files
+}

--- a/scripts/build-bigram-index.ts
+++ b/scripts/build-bigram-index.ts
@@ -35,6 +35,7 @@ import { execSync } from 'node:child_process'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { extractIndexKeys } from '../src/utils/bigramKeys'
+import { splitSqlIntoImportFiles } from './build-bigram-index-split'
 import { buildWranglerEnv } from './wranglerEnv'
 
 const WRANGLER_ENV = buildWranglerEnv()
@@ -298,20 +299,7 @@ async function main(): Promise<void> {
   // 關鍵修正：不再把整批塞進「單一」遠端匯入（會逾時 → Not currently importing anything），
   // 而是把 DELETE + INSERT 切成多個小檔（各 <= IMPORT_FILE_MAX_BYTES）依序匯入。
   // DELETE 放在第一個分檔開頭：任何一檔失敗整體即失敗、CI 報錯，下次重跑會先 DELETE 清空，仍冪等。
-  const fileBodies: string[] = []
-  let body = header
-  for (const stmt of inserts) {
-    const bodyBytes = Buffer.byteLength(body, 'utf-8')
-    const stmtBytes = Buffer.byteLength(stmt, 'utf-8')
-    // 目前分檔非空、且再加一條會超標，就先收檔、開新檔（新檔不再帶 header）。
-    // 守住 body.length > 0：避免單一 INSERT 本身就大於上限時陷入空檔死迴圈。
-    if (body.length > 0 && bodyBytes + stmtBytes > IMPORT_FILE_MAX_BYTES) {
-      fileBodies.push(body)
-      body = ''
-    }
-    body += stmt
-  }
-  if (body.length > 0) fileBodies.push(body)
+  const fileBodies = splitSqlIntoImportFiles(header, inserts, IMPORT_FILE_MAX_BYTES)
 
   const totalParts = fileBodies.length
   console.log(

--- a/scripts/build-bigram-index.ts
+++ b/scripts/build-bigram-index.ts
@@ -22,6 +22,8 @@
  *   TABLE            目標表名（預設 askit_bigram_index，必須 askit_ 前綴）
  *   BIGRAM_DF_MAX    rare-key 文件頻率上限（預設 200，env 可調）
  *   INSERT_CHUNK     每條 INSERT 的列數（預設 500）
+ *   IMPORT_FILE_MAX_BYTES  每個遠端匯入分檔的位元組上限（預設 5MB；避免單一匯入 session 逾時）
+ *   IMPORT_RETRIES   單一分檔匯入失敗時的重試次數（預設 4，指數退避）
  *   LOCAL=1          對 D1 下 --local
  *   DRY_RUN=1        不建表 / 不寫 D1，只報告 sizing
  *   WRANGLER_USE_API_TOKEN=1  wrangler 子行程強制使用 CLOUDFLARE_API_TOKEN（CI 自動啟用）
@@ -43,6 +45,15 @@ const BIGRAM_DF_MAX = Number(process.env.BIGRAM_DF_MAX ?? '200')
 const INSERT_CHUNK = Math.max(1, Number(process.env.INSERT_CHUNK ?? '500'))
 const D1_FLAG = process.env.LOCAL === '1' ? '--local' : '--remote'
 const DRY_RUN = process.env.DRY_RUN === '1'
+// 遠端 D1 匯入是「單一伺服器端 session」：單檔過大（本表 ~33MB / ~2M rows）會逾時，
+// wrangler 隨後輪詢時伺服器已無進行中的匯入，回報「Not currently importing anything.」。
+// 對策：把 INSERT 切成多個小檔（各 <= IMPORT_FILE_MAX_BYTES）依序匯入，每個 session 都短而可靠。
+const IMPORT_FILE_MAX_BYTES = Math.max(
+  64 * 1024,
+  Number(process.env.IMPORT_FILE_MAX_BYTES ?? String(5 * 1024 * 1024)),
+)
+// 對暫時性匯入失敗的重試次數（指數退避）。失敗的匯入會被 D1 回滾，重試是安全的。
+const IMPORT_RETRIES = Math.max(0, Number(process.env.IMPORT_RETRIES ?? '4'))
 
 // 護欄常數（與 vectorize-sync 的 ensureProgressTable 同形）
 const REQUIRED_COLUMNS = ['bigram', 'section_id']
@@ -117,6 +128,32 @@ function d1ExecFile(filePath: string): void {
     `npx wrangler d1 execute ${shellQuote(D1_DATABASE)} ${D1_FLAG} ` +
     `--file ${shellQuote(filePath)} --yes`
   execSync(cmd, { stdio: 'inherit', env: WRANGLER_ENV })
+}
+
+// 同步等待（本腳本為一次性批次工具，可阻塞主執行緒）。跨平台、不需 sleep 子行程。
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+// 匯入單一分檔，失敗時以指數退避重試。失敗的遠端匯入會被 D1 回滾
+//（wrangler：「if the execution fails to complete, your DB will return to its original state」），
+// 加上 INSERT OR IGNORE，重試同一分檔是冪等且安全的。
+function d1ExecFileWithRetry(filePath: string): void {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      d1ExecFile(filePath)
+      return
+    } catch (err) {
+      if (attempt >= IMPORT_RETRIES) throw err
+      const waitMs = 2000 * 2 ** attempt
+      const reason = (err instanceof Error ? err.message : String(err)).split('\n')[0]
+      console.warn(
+        `[build-bigram-index] 匯入 ${path.basename(filePath)} 失敗（第 ${attempt + 1}/${IMPORT_RETRIES} 次重試前），` +
+          `${waitMs}ms 後重試：${reason}`,
+      )
+      sleepSync(waitMs)
+    }
+  }
 }
 
 // ── 安全護欄：絕不蓋過任何已存在的 table ─────────────────────────────────────
@@ -246,24 +283,53 @@ async function main(): Promise<void> {
     console.log('[build-bigram-index] No rare keys to index; 仍會 DELETE 清空既有表。')
   }
 
-  // 重建 SQL：整檔 DELETE + 分批 multi-row INSERT，冪等全量替換我們自己的表。
-  const sqlPath = path.join(outDir, 'bigram-index.sql')
-  let file = `DELETE FROM ${TABLE};\n`
-  let statements = 1
+  // 重建 SQL：整表 DELETE + 分批 multi-row INSERT，冪等全量替換我們自己的表。
+  // INSERT OR IGNORE：碰上 (bigram, section_id) 主鍵衝突就略過，讓「重試同一分檔」安全冪等。
+  const header = `DELETE FROM ${TABLE};\n`
+  const inserts: string[] = []
   for (let i = 0; i < postings.length; i += INSERT_CHUNK) {
     const chunk = postings.slice(i, i + INSERT_CHUNK)
     const values = chunk
       .map(([k, id]) => `(${sqlString(k)},${id})`)
       .join(',')
-    file += `INSERT INTO ${TABLE} (bigram, section_id) VALUES ${values};\n`
-    statements++
+    inserts.push(`INSERT OR IGNORE INTO ${TABLE} (bigram, section_id) VALUES ${values};\n`)
   }
-  await writeFile(sqlPath, file)
+
+  // 關鍵修正：不再把整批塞進「單一」遠端匯入（會逾時 → Not currently importing anything），
+  // 而是把 DELETE + INSERT 切成多個小檔（各 <= IMPORT_FILE_MAX_BYTES）依序匯入。
+  // DELETE 放在第一個分檔開頭：任何一檔失敗整體即失敗、CI 報錯，下次重跑會先 DELETE 清空，仍冪等。
+  const fileBodies: string[] = []
+  let body = header
+  for (const stmt of inserts) {
+    const bodyBytes = Buffer.byteLength(body, 'utf-8')
+    const stmtBytes = Buffer.byteLength(stmt, 'utf-8')
+    // 目前分檔非空、且再加一條會超標，就先收檔、開新檔（新檔不再帶 header）。
+    // 守住 body.length > 0：避免單一 INSERT 本身就大於上限時陷入空檔死迴圈。
+    if (body.length > 0 && bodyBytes + stmtBytes > IMPORT_FILE_MAX_BYTES) {
+      fileBodies.push(body)
+      body = ''
+    }
+    body += stmt
+  }
+  if (body.length > 0) fileBodies.push(body)
+
+  const totalParts = fileBodies.length
   console.log(
-    `[build-bigram-index] Wrote ${sqlPath} (${statements} statements, ${postings.length} rows)`,
+    `[build-bigram-index] ${postings.length} rows → ${inserts.length} INSERT(s) → ` +
+      `${totalParts} import 分檔（每檔 <= ${(IMPORT_FILE_MAX_BYTES / 1024 / 1024).toFixed(1)} MB）`,
   )
-  d1ExecFile(sqlPath)
-  console.log(`[build-bigram-index] Applied ${sqlPath} to ${D1_DATABASE} (${D1_FLAG}).`)
+  for (let i = 0; i < totalParts; i++) {
+    const partPath = path.join(outDir, `bigram-index.part${String(i + 1).padStart(3, '0')}.sql`)
+    await writeFile(partPath, fileBodies[i])
+    const mb = (Buffer.byteLength(fileBodies[i], 'utf-8') / 1024 / 1024).toFixed(2)
+    console.log(
+      `[build-bigram-index] Importing ${path.basename(partPath)} (${i + 1}/${totalParts}, ${mb} MB)...`,
+    )
+    d1ExecFileWithRetry(partPath)
+  }
+  console.log(
+    `[build-bigram-index] Applied ${totalParts} 分檔到 ${D1_DATABASE} (${D1_FLAG}).`,
+  )
   console.log('[build-bigram-index] Done.')
 }
 

--- a/test/buildBigramIndexSplit.test.ts
+++ b/test/buildBigramIndexSplit.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { splitSqlIntoImportFiles } from '../scripts/build-bigram-index-split'
+
+test('splitSqlIntoImportFiles: keeps everything in one file when under the byte limit', () => {
+  const files = splitSqlIntoImportFiles('H;\n', ['A;\n', 'B;\n', 'C;\n'], 100)
+  assert.deepEqual(files, ['H;\nA;\nB;\nC;\n'])
+})
+
+test('splitSqlIntoImportFiles: splits into multiple files, header stays in the first file', () => {
+  const files = splitSqlIntoImportFiles('H;\n', ['A;\n', 'B;\n', 'C;\n'], 5)
+  assert.deepEqual(files, ['H;\n', 'A;\n', 'B;\n', 'C;\n'])
+  for (const f of files) {
+    assert.ok(Buffer.byteLength(f, 'utf-8') <= 5, `oversized part: ${f}`)
+  }
+})
+
+test('splitSqlIntoImportFiles: measures UTF-8 bytes, not characters (CJK)', () => {
+  // 「萌典;\n」= 6 (兩個 3-byte 漢字) + 2 = 8 bytes，但只有 4 個字元。
+  // maxBytes=10 下，header(3) + 8 = 11 > 10 必須切檔；若誤用字元長度則不會切。
+  const stmt = '萌典;\n'
+  assert.equal(Buffer.byteLength(stmt, 'utf-8'), 8)
+  const files = splitSqlIntoImportFiles('H;\n', [stmt, stmt], 10)
+  assert.deepEqual(files, ['H;\n', stmt, stmt])
+})
+
+test('splitSqlIntoImportFiles: an oversized single statement gets its own file (no infinite loop, no empty file)', () => {
+  const big = 'XXXXX;\n' // 7 bytes > maxBytes
+  const files = splitSqlIntoImportFiles('H;\n', [big], 4)
+  assert.deepEqual(files, ['H;\n', big])
+  for (const f of files) assert.ok(f.length > 0, 'no empty file body')
+})
+
+test('splitSqlIntoImportFiles: empty statement list still emits the header file', () => {
+  assert.deepEqual(splitSqlIntoImportFiles('H;\n', [], 5), ['H;\n'])
+})


### PR DESCRIPTION
CI 在 `npm run index:bigram` 失敗：腳本把整批（~33MB / ~2M rows /
3972 statements）寫成單一 SQL 檔，再以一次 `wrangler d1 execute --remote
--file` 匯入。遠端匯入是單一伺服器端 session，這麼大的負載會逾時，wrangler
隨後輪詢時伺服器已無進行中的匯入，回報「Not currently importing anything.」
（log 顯示處理到 ~3664/3972 才崩）。

改法：
- 把 DELETE + INSERT 切成多個小分檔（各 <= IMPORT_FILE_MAX_BYTES，預設 5MB），
  依序匯入，每個匯入 session 都短而可靠（~33MB → 約 7-8 檔）。
- INSERT 改 INSERT OR IGNORE；DELETE 仍置於第一分檔開頭，整體維持冪等全量替換，
  且重試單一分檔安全。
- 新增 d1ExecFileWithRetry：對暫時性匯入失敗指數退避重試（IMPORT_RETRIES，預設 4）。
  失敗的遠端匯入會被 D1 回滾，重試是安全的。
- 新增 env：IMPORT_FILE_MAX_BYTES、IMPORT_RETRIES。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HdYDz4awkeyWDScYuYiimp