### PR TITLE
/au 的 GET CORS 對齊 /cag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1174,6 +1174,8 @@ app.get('/au/status', (c) => {
   })
 })
 
+app.options('/au/:question', askCorsPreflight)
+
 app.get('/au/:question', async (c) => {
   const lang = resolveWebLang(c.req.query('lang'))
   const messages = WEB_MESSAGES[lang]
@@ -1182,17 +1184,17 @@ app.get('/au/:question', async (c) => {
   const trusted = await isTrustedCaller(c)
   const abuse = trusted ? null : await checkHttpBlacklist(c)
   if (abuse?.blocked) {
-    return c.text(messages.blacklisted, 403)
+    return applyAskCors(c, c.text(messages.blacklisted, 403))
   }
   if (!trusted && await isIpRateLimited(c)) {
     reportAbuse(c, { key: abuse?.key ?? null, kind: 'rate_limit', path: 'au', question, ip: abuse?.ip })
-    return c.text(messages.rateLimited, 429, {
+    return applyAskCors(c, c.text(messages.rateLimited, 429, {
       'Retry-After': String(RATE_LIMIT_RETRY_AFTER_SECONDS),
-    })
+    }))
   }
   if (isQuestionTooLong(question)) {
     reportAbuse(c, { key: abuse?.key ?? null, kind: 'question_too_long', path: 'au', question, ip: abuse?.ip })
-    return c.text(messages.tooLong, 400)
+    return applyAskCors(c, c.text(messages.tooLong, 400))
   }
 
   const bypassCache = shouldBypassCaches(c.req.query('refresh'))
@@ -1241,26 +1243,26 @@ app.get('/au/:question', async (c) => {
     const cached = await getCachedResponse(c.env.ASK_CACHE, cacheKey)
     if (cached) {
       c.executionCtx.waitUntil(refreshCachedResponse(c.env.ASK_CACHE, cacheKey, cached))
-      return respondFromCache(cached.body, cached.contentType)
+      return applyAskCors(c, respondFromCache(cached.body, cached.contentType))
     }
   }
 
   const budget = trusted ? { allowed: true } : await checkGlobalGenerationBudget(c.env)
   if (!budget.allowed) {
-    return c.text(messages.budget, 429, {
+    return applyAskCors(c, c.text(messages.budget, 429, {
       'Retry-After': retryAfterForBudget(budget),
-    })
+    }))
   }
 
   const response = await streamCagAnswer(c.env.AI, question, cagOptions)
   if (response.status === 404 && lang === 'en') {
     await response.body?.cancel()
-    return new Response(NOT_FOUND_REPLY_HTML_EN, {
+    return applyAskCors(c, new Response(NOT_FOUND_REPLY_HTML_EN, {
       status: 404,
       headers: response.headers,
-    })
+    }))
   }
-  return cacheCagResponse(c, bypassCache ? null : cacheKey, response)
+  return applyAskCors(c, cacheCagResponse(c, bypassCache ? null : cacheKey, response))
 })
 
 app.post('/au', async (c) => {

--- a/test/auCors.test.ts
+++ b/test/auCors.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import app from '../src/index'
+
+// /au 的 GET CORS 對齊 /cag（OPTIONS 預檢 + 各回應分支都帶 CORS）。
+// 用同一組斷言跑過兩條路由，鎖住「兩者 CORS 行為一致」這個對齊：日後任一條
+// 漏掉 applyAskCors 或 OPTIONS 註冊，這裡就會紅。打法沿用 capacity/cag 測試的
+// app.request(path, init, env, ctx) + 最小 stub env。
+
+const ALLOWED_ORIGIN = 'https://archive.tw'
+const UNLISTED_ORIGIN = 'https://evil.example'
+
+// 答案端點（/cag、/au）共用的 CORS 常數；與 src/index.ts 的 ASK_CORS_* 對齊。
+const EXPECTED_METHODS = 'GET, OPTIONS'
+const EXPECTED_HEADERS = 'Content-Type'
+const EXPECTED_MAX_AGE = '600'
+
+// app.request 預設不帶 executionCtx；被擋下的分支會 waitUntil 背景寫 abuse log，
+// 故提供 no-op stub（與真實 Worker runtime 一致）。
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+  props: {},
+} as unknown as ExecutionContext
+
+// 命中即回固定內容的 R2 cache stub（忽略 key）→ GET 走「快取命中」分支回 200。
+function cachedBucket(body: string, contentType: string) {
+  return {
+    async get() {
+      return {
+        uploaded: new Date(),
+        httpMetadata: { contentType },
+        async text() {
+          return body
+        },
+      }
+    },
+    async put() {},
+    async delete() {},
+  }
+}
+
+// 永遠回「超量」的內建限流 stub → 未受信任時 isIpRateLimited 為 true、GET 回 429。
+function rateLimitedEnv() {
+  return { RATE_LIMITER: { limit: async () => ({ success: false }) } }
+}
+
+// 一個短問題，兩條路由共用；ASCII 即可，cache stub 不在意實際 key。
+const QUESTION = 'hello'
+
+for (const route of ['cag', 'au'] as const) {
+  const path = `/${route}/${QUESTION}`
+
+  test(`OPTIONS ${path} returns CORS preflight headers for archive.tw`, async () => {
+    const res = await app.request(
+      path,
+      { method: 'OPTIONS', headers: { Origin: ALLOWED_ORIGIN } },
+      {},
+      ctx,
+    )
+
+    assert.equal(res.status, 204)
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), ALLOWED_ORIGIN)
+    assert.equal(res.headers.get('Access-Control-Allow-Methods'), EXPECTED_METHODS)
+    assert.equal(res.headers.get('Access-Control-Allow-Headers'), EXPECTED_HEADERS)
+    assert.equal(res.headers.get('Access-Control-Max-Age'), EXPECTED_MAX_AGE)
+  })
+
+  test(`OPTIONS ${path} does not echo CORS for unlisted origins`, async () => {
+    const res = await app.request(
+      path,
+      { method: 'OPTIONS', headers: { Origin: UNLISTED_ORIGIN } },
+      {},
+      ctx,
+    )
+
+    assert.equal(res.status, 204)
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), null)
+  })
+
+  test(`GET ${path} carries CORS headers for archive.tw on a cached answer`, async () => {
+    const res = await app.request(
+      path,
+      { headers: { Origin: ALLOWED_ORIGIN } },
+      {
+        ASK_CACHE: cachedBucket('cached answer', 'text/markdown; charset=UTF-8'),
+      },
+      ctx,
+    )
+
+    assert.equal(res.status, 200)
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), ALLOWED_ORIGIN)
+    assert.equal(res.headers.get('Access-Control-Allow-Methods'), EXPECTED_METHODS)
+    assert.equal(res.headers.get('Access-Control-Allow-Headers'), EXPECTED_HEADERS)
+    assert.match(res.headers.get('Vary') ?? '', /\bOrigin\b/)
+  })
+
+  test(`GET ${path} does not echo CORS for unlisted origins`, async () => {
+    const res = await app.request(
+      path,
+      { headers: { Origin: UNLISTED_ORIGIN } },
+      {
+        ASK_CACHE: cachedBucket('cached answer', 'text/markdown; charset=UTF-8'),
+      },
+      ctx,
+    )
+
+    assert.equal(res.status, 200)
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), null)
+  })
+
+  test(`GET ${path} carries CORS headers on an early-return (429) for archive.tw`, async () => {
+    const res = await app.request(
+      path,
+      { headers: { Origin: ALLOWED_ORIGIN, 'cf-connecting-ip': '203.0.113.10' } },
+      rateLimitedEnv(),
+      ctx,
+    )
+
+    assert.equal(res.status, 429)
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), ALLOWED_ORIGIN)
+    assert.equal(res.headers.get('Retry-After'), '3')
+  })
+}


### PR DESCRIPTION
## 背景

`/cag/:question` 的 GET 有完整的 CORS：註冊了 `OPTIONS` 預檢，且每個回應分支都包了 `applyAskCors`，跨來源（`archive.tw` / `ask.archive.tw` / `localhost:8787`）的瀏覽器呼叫都能拿到 CORS 標頭。

`/au/:question` 的 GET 則兩者皆無 — 沒有 `OPTIONS` 預檢、回應也不帶 CORS 標頭，導致同樣的跨來源呼叫被瀏覽器擋下。

本 PR 把 `/au` 的 GET CORS **逐字對齊** `/cag`。

## 改動

**`src/index.ts`**
- 新增 `app.options('/au/:question', askCorsPreflight)`（與 `/cag` 一樣回 204 + CORS 標頭）。
- `/au/:question` GET 的 **7 個回應分支** 全部包上 `applyAskCors(c, ...)`，與 `/cag/:question` 對齊：
  - 黑名單 403、限流 429、問題過長 400、快取命中、預算 429、英文 404、最終串流答案。
- 兩條路由共用同一套 `ASK_CORS_*` 常數（允許來源、方法 `GET, OPTIONS`、標頭 `Content-Type`、`Max-Age 600`）。
- `applyAskCors` 僅在 `Origin` 命中白名單時加標頭，**非 CORS 請求行為不變**。

**`test/auCors.test.ts`（新增）**

用同一組斷言跑過 `/cag` 與 `/au` 兩條路由，鎖住「兩者 GET CORS 行為一致」。每條路由 5 個案例（共 10 個）：

| 案例 | 驗證 |
|---|---|
| `OPTIONS …`（archive.tw） | 204 + `Allow-Origin`/`Methods`/`Headers`/`Max-Age` |
| `OPTIONS …`（未列名來源） | 204 但不回 `Allow-Origin` |
| `GET …` 快取命中（archive.tw） | 200 + CORS 標頭 + `Vary: Origin` |
| `GET …` 快取命中（未列名來源） | 200 但不回 `Allow-Origin` |
| `GET …` 限流早退 429（archive.tw） | 429 + `Allow-Origin`（驗證 early-return 分支也包了 CORS） |

## 驗證

- `npm run typecheck` ✅
- 相關 4 檔 `auCors / cag / capacity / trustedCaller` 共 **93 個測試全過**。
- 回歸守門有效：暫時拿掉 `/au` 的 `OPTIONS` 註冊，新測試立刻變紅，確認非空測試。

> 備註：`test/abuse.test.ts` 在本機（Node 20）因 `node:sqlite` 需要 Node 22+ 而於 import 階段失敗，屬既有環境問題，與本 PR 無關。

🤖 Generated with [Claude Code](https://claude.com/claude-code)