### PR TITLE
/webhook 的生成回答對齊 /au，而非 /cag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,14 +163,15 @@ const WEBHOOK_CAG_CITE_TOP_K = 4
 const WEBHOOK_CAG_MAX_COMPLETION_TOKENS = 240
 // LINE 載入動畫秒數需為 5～60 的 5 倍數，且僅 1:1 聊天有效。
 const WEBHOOK_LOADING_SECONDS = 30
-// 要求模型在 token 預算內「把話講完」，避免回答被 max_completion_tokens 從中截斷。
-const WEBHOOK_CAG_ANSWER_INSTRUCTION =
-  '請以繁體中文用 3～5 句話簡潔作答，全文控制在約 200 字內並完整收尾，' +
-  '於陳述具體事實時標註 [1]、[2] 等來源編號。'
-// 偵測到全英文提問（issue #37）時改用此英文指示，與 answerLanguage:'en' 一致，避免中英衝突。
-const WEBHOOK_CAG_ANSWER_INSTRUCTION_EN =
-  'Answer in English in 3–5 concise sentences, keep the whole reply within about 100 words ' +
-  'and finish cleanly, and cite source numbers like [1], [2] when stating concrete facts.'
+// webhook 的回答生成對齊 /au（唐鳳公開溝通風格、Audrey skill 模型、SayIt 來源救援），
+// 僅在 buildAudreySkillAnswerInstruction 之後再追加這段「長度上限」：把答案壓在 LINE 對話框
+// 適讀的長度，並要求模型在 token 預算內把話講完，避免被 max_completion_tokens 從中截斷。
+// 引註規則（標註 [1]、[2]）已由 Audrey skill 指示涵蓋，這裡不重述。
+const WEBHOOK_CAG_LENGTH_INSTRUCTION =
+  '請用 3～5 句話簡潔作答，全文控制在約 200 字內並完整收尾。'
+// 偵測到全英文提問（issue #37）時改用此英文版，與 answerLanguage:'en' 一致，避免中英衝突。
+const WEBHOOK_CAG_LENGTH_INSTRUCTION_EN =
+  'Keep the whole reply within about 100 words across 3–5 concise sentences and finish cleanly.'
 // 限流冷卻視窗：同一使用者於此毫秒數內最多 1 次（對齊首頁送出鈕冷卻）。
 const RATE_LIMIT_WINDOW_MS = 3_000
 const NOT_FOUND_REPLY_MIN_DELAY_MS = RATE_LIMIT_WINDOW_MS
@@ -982,11 +983,13 @@ async function replyWithCag(
   // 全英文提問（issue #37）：以英文生成並回覆固定訊息；含中文則沿用預設繁中。
   const answerLanguage = detectCagAnswerLanguage(question)
   const lang: WebMessageLang = answerLanguage === 'en' ? 'en' : 'zh-Hant'
+  // 回答生成對齊 /au：用 Audrey skill 模型（AUDREY_MODEL 未設時與 DEFAULT_CAG_MODEL 同為 Gemma）。
+  const model = resolveAudreySkillModel(env.AUDREY_MODEL)
   // 快取：相同問題（retriever／model／語言相同）7 天內直接用快取的答案與來源回覆，不跑檢索與 AI。
   // answerLanguage 由問題字元決定，故同一問題語言固定；en 入 key 避免沿用舊的繁中快取項。
   const cacheKey = await buildCacheKey('webhook', question, {
     retriever,
-    model: DEFAULT_CAG_MODEL,
+    model,
     answerLanguage,
   })
   const cached = await getCachedResponse(env.ASK_CACHE, cacheKey)
@@ -1021,15 +1024,20 @@ async function replyWithCag(
       topK: WEBHOOK_CAG_TOP_K,
       citableTopK: WEBHOOK_CAG_CITE_TOP_K,
       maxCompletionTokens: WEBHOOK_CAG_MAX_COMPLETION_TOKENS,
+      model,
+      // 對齊 /au 的唐鳳風格回答指示，再追加 LINE 對話框適讀的長度上限。
       answerInstruction:
-        answerLanguage === 'en'
-          ? WEBHOOK_CAG_ANSWER_INSTRUCTION_EN
-          : WEBHOOK_CAG_ANSWER_INSTRUCTION,
+        buildAudreySkillAnswerInstruction(answerLanguage) +
+        ' ' +
+        (answerLanguage === 'en'
+          ? WEBHOOK_CAG_LENGTH_INSTRUCTION_EN
+          : WEBHOOK_CAG_LENGTH_INSTRUCTION),
       answerLanguage,
       retriever,
       vectorize: env.VECTORIZE,
       vectorizeMinScore: resolveVectorizeMinScore(env.CAG_VECTORIZE_MIN_SCORE),
       cagCache: env.CAG_CACHE,
+      sayitDb: env.SAYIT_DB,
     })
   } catch (e) {
     cagFailed = true

--- a/test/cag.test.ts
+++ b/test/cag.test.ts
@@ -1425,11 +1425,13 @@ test('webhook answers all-English questions in English (issue #37)', async () =>
     await Promise.all(waitUntilPromises)
 
     // 模型收到的指示確實切到英文：system 要求英文作答，user 帶英文版回答指示。
+    // 回答生成對齊 /au：user 指示為唐鳳公開溝通風格，再追加 LINE 適讀的長度上限。
     assert.equal(completionMessages.length, 1)
     const [system, user] = completionMessages[0]
     assert.match(system.content, /Answer in English/)
     assert.doesNotMatch(system.content, /Use Traditional Chinese/)
-    assert.match(user.content, /Answer in English in 3–5 concise sentences/)
+    assert.match(user.content, /Answer in English in Audrey Tang's public communication style/)
+    assert.match(user.content, /within about 100 words across 3–5 concise sentences/)
 
     // 回覆確實送出英文答案。
     const replyCall = fetchCalls.find(


### PR DESCRIPTION
## 摘要

把 `/webhook`（LINE bot）的**回答生成行為**從 `/cag`-風格切換為與 `/au` 一致的「唐鳳人設」生成。

`replyWithCag` 內的 `generateCagAnswer` 呼叫改為：

| 項目 | 變更前（`/cag`-風格） | 變更後（對齊 `/au`） |
|---|---|---|
| 模型 | `DEFAULT_CAG_MODEL` | `resolveAudreySkillModel(env.AUDREY_MODEL)` |
| 回答指示 | 通用簡潔 CAG prompt | `buildAudreySkillAnswerInstruction()`（唐鳳公開溝通風格 + 引註規則） |
| SayIt 來源救援 | 未傳入 | `sayitDb: env.SAYIT_DB` |
| 快取 key 模型 | `DEFAULT_CAG_MODEL` | 解析後的 Audrey 模型 |

## 保留 LINE 適讀長度

依 LINE 對話框需求，**保留** webhook 既有的短答設定（`max_tokens=240`、`top_k`／`cite_top_k=4`）。
舊的 `WEBHOOK_CAG_ANSWER_INSTRUCTION{,_EN}` 由 `WEBHOOK_CAG_LENGTH_INSTRUCTION{,_EN}` 取代——只保留「長度上限」段落，接在 Audrey 指示之後，避免答案被 `max_completion_tokens` 從中截斷。

## 備註

- `AUDREY_SKILL_DEFAULT_MODEL` 與 `DEFAULT_CAG_MODEL` 同為 Gemma，故僅在 `AUDREY_MODEL` 環境變數設為 GLM-5.2 時模型才會不同；未設時既有 webhook 快取項仍有效。
- Flex 訊息出貨（`formatCagAnswerFlex`、4 格出處）屬「投遞」而非「生成」，維持原樣不動。

## 測試

- `tsc --noEmit`：通過
- `test/cag.test.ts`：56/56 通過（更新了原本鎖定舊指示字串的英文 webhook 測試，改為斷言 Audrey 人設 + 長度上限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)